### PR TITLE
Update secrets handling and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
             - uses: actions/setup-python@v5
               with:
-                  python-version: "3.9"
+                  python-version: "3.14"
 
             - name: Install uv and dependencies
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: Tests
 
 on:
     push:
+        branches: ["**"]
     pull_request:
+        branches: ["**"]
 
 concurrency:
     group: fatsecret-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
             - uses: actions/setup-python@v5
               with:
-                  python-version: "3.14"
+                  python-version: "3.9"
 
             - name: Install uv and dependencies
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
             - uses: actions/setup-python@v5
               with:
-                  python-version: "3.9"
+                  python-version: "3.14"
 
             - name: Install uv and dependencies
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,27 @@
-name: CI
+name: Tests
 
 on:
     push:
-        branches: [main, master]
     pull_request:
-        branches: [main, master]
 
 jobs:
     test:
         runs-on: ubuntu-latest
+
+        env:
+            FATSECRET_CONSUMER_KEY: ${{ secrets.FATSECRET_CONSUMER_KEY }}
+            FATSECRET_CONSUMER_SECRET: ${{ secrets.FATSECRET_CONSUMER_SECRET }}
+
         steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-
-            - name: Set up Python
-              uses: actions/setup-python@v5
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
               with:
-                  python-version: "3.11"
+                  python-version: "3.9"
 
-            - name: Install uv
-              run: pip install uv
-
-            - name: Install dependencies
-              run: uv sync --all-extras
+            - name: Install uv and dependencies
+              run: |
+                  pip install uv
+                  uv sync --all-extras
 
             # - name: Run lint
             #   run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     push:
     pull_request:
 
+concurrency:
+    group: fatsecret-tests
+    cancel-in-progress: false # ensures one workflow at a time, no cancellation
+
 jobs:
     test:
         runs-on: ubuntu-latest
@@ -14,6 +18,7 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+
             - uses: actions/setup-python@v5
               with:
                   python-version: "3.9"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ docs/_build/*
 
 # Coverage reports
 coverage.xml
+
+# Environment files
+.env
+

--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,15 @@ clean:  ## Remove build artifacts and caches
 COV_OPTS := --cov=$(SRC_DIR) --cov-report=term-missing --cov-report=xml:coverage.xml
 
 test:  ## Run all tests with coverage
-	@uv run pytest $(COV_OPTS)
+	@uv run pytest -s $(COV_OPTS)
 	@rm -f .coverage
 
 test-unit:  ## Run only unit tests with coverage
-	@uv run pytest $(COV_OPTS) $(TEST_DIR)/unit
+	@uv run pytest -s $(COV_OPTS) $(TEST_DIR)/unit
 	@rm -f .coverage
 
 test-int:  ## Run only integration tests with coverage
-	@uv run pytest $(COV_OPTS) -m integration
+	@uv run pytest -s $(COV_OPTS) -m integration
 	@rm -f .coverage
 
 # -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "isort",
     "pytest-cov",
     "pytest",
+    "python-dotenv",
     "rauth==0.7.3",
     "requests==2.32.5",
     "ruff",
@@ -16,3 +17,6 @@ dependencies = [
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+markers = [
+    "integration: mark a test as an integration test"
+]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+from fatsecret import Fatsecret
+
+
+@pytest.fixture(scope="module")
+def fatsecret_client():
+    """Fixture to initialize Fatsecret client for integration tests."""
+
+    if not os.getenv("GITHUB_ACTIONS"):
+        load_dotenv()
+
+    consumer_key = os.getenv("FATSECRET_CONSUMER_KEY")
+    consumer_secret = os.getenv("FATSECRET_CONSUMER_SECRET")
+
+    if not consumer_key or not consumer_secret:
+        pytest.skip("❌ Missing Fatsecret credentials in environment variables")
+
+    fs = Fatsecret(consumer_key, consumer_secret)
+    yield fs
+    fs.close()

--- a/tests/integration/test_foods_integration.py
+++ b/tests/integration/test_foods_integration.py
@@ -9,8 +9,6 @@ def test_food_get_basic(fatsecret_client):
     food_id = "4380"
 
     result = fatsecret_client.food_get(food_id)
-    pprint("result")
-    pprint(result)
 
     # Basic sanity checks
     assert isinstance(result, dict)

--- a/tests/integration/test_foods_integration.py
+++ b/tests/integration/test_foods_integration.py
@@ -1,0 +1,19 @@
+from pprint import pprint
+
+import pytest
+
+
+@pytest.mark.integration
+def test_food_get_basic(fatsecret_client):
+    """Test a simple public call to the Fatsecret API."""
+    food_id = "4380"
+
+    result = fatsecret_client.food_get(food_id)
+    pprint("result")
+    pprint(result)
+
+    # Basic sanity checks
+    assert isinstance(result, dict)
+    assert "food_id" in result
+    assert result["food_id"] == food_id
+    assert "food_name" in result

--- a/uv.lock
+++ b/uv.lock
@@ -580,6 +580,7 @@ dependencies = [
     { name = "isort", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "python-dotenv" },
     { name = "rauth" },
     { name = "requests" },
     { name = "ruff" },
@@ -591,8 +592,9 @@ requires-dist = [
     { name = "isort" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "rauth", specifier = "==0.7.3" },
-    { name = "requests", specifier = "==2.32.5" },
+    { name = "python-dotenv" },
+    { name = "rauth" },
+    { name = "requests" },
     { name = "ruff" },
 ]
 
@@ -637,6 +639,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -593,8 +593,8 @@ requires-dist = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "python-dotenv" },
-    { name = "rauth" },
-    { name = "requests" },
+    { name = "rauth", specifier = "==0.7.3" },
+    { name = "requests", specifier = "==2.32.5" },
     { name = "ruff" },
 ]
 


### PR DESCRIPTION
Limit concurrent CI runs, add integration test for food_get and improve secrets handling

This pull request improves CI pipeline efficiency by limiting concurrent runs for push and pull_request events. It adds an integration test for the Fatsecret food_get method to ensure API correctness and verifies credentials are present through updated secrets handling. This helps address stability of tests, CI speed and coverage for essential endpoints.