### PR TITLE
Fix epoch calculation to ensure UTC consistency

### DIFF
--- a/src/fatsecret/fatsecret.py
+++ b/src/fatsecret/fatsecret.py
@@ -182,7 +182,9 @@ class Fatsecret:
         :param dt: Date to convert
         :type dt: datetime.datetime
         """
-        epoch = datetime.datetime.fromtimestamp(0, datetime.timezone.utc).replace(tzinfo=None)
+        epoch = datetime.datetime.fromtimestamp(0, datetime.timezone.utc).replace(
+            tzinfo=None
+        )
         delta = dt - epoch
         return delta.days
 

--- a/src/fatsecret/fatsecret.py
+++ b/src/fatsecret/fatsecret.py
@@ -182,7 +182,7 @@ class Fatsecret:
         :param dt: Date to convert
         :type dt: datetime.datetime
         """
-        epoch = datetime.datetime.utcfromtimestamp(0)
+        epoch = datetime.datetime.fromtimestamp(0, datetime.timezone.utc).replace(tzinfo=None)
         delta = dt - epoch
         return delta.days
 

--- a/tests/unit/test_core_utils.py
+++ b/tests/unit/test_core_utils.py
@@ -4,7 +4,35 @@ from fatsecret import Fatsecret
 
 
 def test_unix_time_epoch():
-    assert Fatsecret.unix_time(datetime.datetime(1970, 1, 2)) == 1
+    dt = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+    dt_naive = dt.replace(tzinfo=None)
+    assert Fatsecret.unix_time(dt_naive) == 0
+
+
+def test_unix_time_one_day():
+    dt = datetime.datetime.fromtimestamp(0, datetime.timezone.utc) + datetime.timedelta(
+        days=1
+    )
+    dt_naive = dt.replace(tzinfo=None)
+    assert Fatsecret.unix_time(dt_naive) == 1
+
+
+def test_unix_time_leap_year():
+    dt = datetime.datetime(1972, 1, 1, tzinfo=datetime.timezone.utc)
+    epoch = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+    dt_naive = dt.replace(tzinfo=None)
+    epoch_naive = epoch.replace(tzinfo=None)
+    expected_days = (dt_naive - epoch_naive).days
+    assert Fatsecret.unix_time(dt_naive) == expected_days
+
+
+def test_unix_time_far_future():
+    dt = datetime.datetime(2100, 1, 1, tzinfo=datetime.timezone.utc)
+    epoch = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+    dt_naive = dt.replace(tzinfo=None)
+    epoch_naive = epoch.replace(tzinfo=None)
+    expected_days = (dt_naive - epoch_naive).days
+    assert Fatsecret.unix_time(dt_naive) == expected_days
 
 
 def test_api_url_constant():


### PR DESCRIPTION
Fix epoch calculation to ensure UTC consistency

This PR updates the epoch reference in unix_time calculations to ensure it is always consistent with UTC, addressing issues with naive datetimes. The included tests verify behavior for edge cases.