### PR TITLE
Add unix_time_v2 to support more input types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: Tests
 
 on:
     push:
-        branches: ["**"]
+        branches:
+            - master
     pull_request:
         branches: ["**"]
 

--- a/src/fatsecret/fatsecret.py
+++ b/src/fatsecret/fatsecret.py
@@ -187,6 +187,30 @@ class Fatsecret:
         return delta.days
 
     @staticmethod
+    def unix_time_v2(dt):
+        """Convert the provided datetime, date, or timestamp into number of days since the Epoch (Jan 1, 1970).
+
+        :param dt: Date to convert (datetime, date, or timestamp)
+        :type dt: datetime.datetime | datetime.date | int | float
+        """
+        epoch = datetime.datetime(1970, 1, 1)
+        if isinstance(dt, datetime.datetime):
+            delta = dt - epoch
+            return delta.days
+        elif isinstance(dt, datetime.date):
+            delta = datetime.datetime(dt.year, dt.month, dt.day) - epoch
+            return delta.days
+        elif isinstance(dt, (int, float)):
+            # treat as unix timestamp, use timezone-aware UTC
+            dt_utc = datetime.datetime.fromtimestamp(
+                dt, tz=datetime.timezone.utc
+            ).replace(tzinfo=None)
+            delta = dt_utc - epoch
+            return delta.days
+        else:
+            raise TypeError("dt must be datetime, date, int, or float")
+
+    @staticmethod
     def valid_response(response):
         """Helper function to check JSON response for errors and to strip headers
 

--- a/tests/unit/test_core_utils.py
+++ b/tests/unit/test_core_utils.py
@@ -7,6 +7,49 @@ def test_unix_time_epoch():
     assert Fatsecret.unix_time(datetime.datetime(1970, 1, 2)) == 1
 
 
+def test_unix_time_v2_datetime():
+    dt = datetime.datetime(1970, 1, 2)
+    assert Fatsecret.unix_time_v2(dt) == 1
+
+
+def test_unix_time_v2_date():
+    dt = datetime.date(1970, 1, 3)
+    assert Fatsecret.unix_time_v2(dt) == 2
+
+
+def test_unix_time_v2_timestamp():
+    ts = 86400 * 4  # 4 days after epoch
+    assert Fatsecret.unix_time_v2(ts) == 4
+
+
+def test_unix_time_v2_float_timestamp():
+    ts = 86400.0 * 5  # 5 days after epoch
+    assert Fatsecret.unix_time_v2(ts) == 5
+
+
+def test_unix_time_v2_invalid_type():
+    try:
+        Fatsecret.unix_time_v2("not a date")
+    except TypeError as e:
+        assert "dt must be datetime, date, int, or float" in str(e)
+    else:
+        assert False, "TypeError not raised for invalid input type"
+
+
+def test_unix_time_v2_leap_year():
+    dt = datetime.datetime(1972, 1, 1)
+    epoch = datetime.datetime(1970, 1, 1)
+    expected_days = (dt - epoch).days
+    assert Fatsecret.unix_time_v2(dt) == expected_days
+
+
+def test_unix_time_v2_far_future():
+    dt = datetime.datetime(2100, 1, 1)
+    epoch = datetime.datetime(1970, 1, 1)
+    expected_days = (dt - epoch).days
+    assert Fatsecret.unix_time_v2(dt) == expected_days
+
+
 def test_api_url_constant():
     fs = Fatsecret("key", "secret")
     assert fs.api_url == "https://platform.fatsecret.com/rest/server.api"


### PR DESCRIPTION
Restrict CI workflows to only run on push events to the master branch, preventing unnecessary runs on other branches. Introduce the unix_time_v2 method to Fatsecret, which supports datetime, date, and numeric timestamp inputs for greater flexibility in date calculations. Comprehensive tests were added to ensure correct behavior. This PR addresses the need to both limit CI execution and to improve date handling functionality as outlined in the ticket.