### PR TITLE
Add serve target to Makefile for local documentation hosting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PYTEST := uv run pytest
 SRC_DIR := src/fatsecret
 TEST_DIR := tests
 DOCS_DIR := docs
+DOCS_PORT ?= 10161
 
 .DEFAULT_GOAL := help
 
@@ -83,13 +84,17 @@ release: build  ## Publish to PyPI using uv
 # -----------------------------
 # Misc
 # -----------------------------
-.PHONY: help all example docs
+.PHONY: help all example docs docs-serve
 
 example: fmt lint  ## Run the CLI example with API credentials from environment
 	@PYTHONPATH=src uv run python examples/cli_example.py
 
 docs:  ## Build Sphinx documentation (clean then html)
 	@cd docs && make clean && make html
+
+serve: docs  ## Build then serve docs on localhost:10161 (override with DOCS_PORT=<port>)
+	@echo "Serving docs at http://localhost:$(DOCS_PORT) (Ctrl+C to stop)"
+	@cd docs/_build/html && $(PYTHON) -m http.server $(DOCS_PORT)
 
 help:  ## Show available make targets
 	@echo "Available commands:"

--- a/uv.lock
+++ b/uv.lock
@@ -510,6 +510,44 @@ wheels = [
 ]
 
 [[package]]
+name = "fatsecret"
+version = "0.5.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "black" },
+    { name = "bs4" },
+    { name = "isort", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "isort", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "lxml" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "python-dotenv" },
+    { name = "rauth" },
+    { name = "requests" },
+    { name = "ruff" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-rtd-theme" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black" },
+    { name = "bs4" },
+    { name = "isort" },
+    { name = "lxml" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "python-dotenv" },
+    { name = "rauth", specifier = "==0.7.3" },
+    { name = "requests", specifier = "==2.32.5" },
+    { name = "ruff" },
+    { name = "sphinx", specifier = ">=7.4.7" },
+    { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -899,44 +937,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "pyfatsecret-chocotonic"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "black" },
-    { name = "bs4" },
-    { name = "isort", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "isort", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "lxml" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "python-dotenv" },
-    { name = "rauth" },
-    { name = "requests" },
-    { name = "ruff" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "sphinx-rtd-theme" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "black" },
-    { name = "bs4" },
-    { name = "isort" },
-    { name = "lxml" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "python-dotenv" },
-    { name = "rauth", specifier = "==0.7.3" },
-    { name = "requests", specifier = "==2.32.5" },
-    { name = "ruff" },
-    { name = "sphinx", specifier = ">=7.4.7" },
-    { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add fatsecret package and local docs serve target

This pull request introduces the fatsecret package in the dependency lock file, consolidating requirements previously under the pyfatsecret-chocotonic package. It also adds a serve target to the Makefile, making it easier to build and locally preview documentation, which improves the development and documentation workflow.