### PR TITLE
Add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "03:00"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"


### PR DESCRIPTION
Extends dependabot to also keep GitHub Actions versions up to date alongside uv packages. Both run weekly on Monday at 3am UTC.