### PR TITLE
Fix automerge missing workflows permission

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  workflows: write
 
 jobs:
   automerge:


### PR DESCRIPTION
Adds workflows: write permission so dependabot can auto-merge PRs that modify workflow files.