### PR TITLE
Fix automerge: use pull_request_target for secret access

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto-Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:


### PR DESCRIPTION
pull_request events don't expose secrets to dependabot PRs. pull_request_target runs in the base branch context with full secret access, which is what gh pr merge --auto needs.