### PR TITLE
Fix automerge: remove invalid workflows permission, use RELEASE_PAT

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   pull-requests: write
   contents: write
-  workflows: write
 
 jobs:
   automerge:
@@ -20,4 +19,4 @@ jobs:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
- Remove invalid 'workflows' permission (only valid for PATs, not GITHUB_TOKEN)
- Use RELEASE_PAT which already has workflow file permissions for merging