### PR TITLE
chore: group dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "03:00"
+    groups:
+      python-deps:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -14,3 +18,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "03:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- All `uv` dependency updates will be batched into a single weekly PR (`python-deps` group)
- All `github-actions` updates will be batched into a single weekly PR (`github-actions` group)

Previously each package got its own PR (e.g. 4 separate PRs for actions bumps). Now it's 1 PR per ecosystem per week.