### PR TITLE
docs: surface v1.0 versioning + OAuth2 in Sphinx docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,15 @@
 API Documentation
 =================
 
+As of v1.0 every endpoint method carries an explicit ``_vN`` suffix matching
+the upstream API version (e.g. ``foods_search_v5``, ``food_get_v5``,
+``recipes_search_v3``). The unsuffixed legacy names (``foods_search``,
+``food_get``, ...) remain available as **deprecated aliases** for the v1.x
+line and emit :class:`DeprecationWarning` when called. To surface those
+warnings during development, run Python with::
+
+    python -W default::DeprecationWarning:fatsecret
+
 .. autoclass:: fatsecret.Fatsecret
     :members:
     :noindex:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,13 @@ the data retrieved from the API. To that end, this library will usually return l
 plotting, discarding extra header fields that the Fatsecret API otherwise includes. All API calls return either a
 single or list of JSON dictionaries.
 
+.. note::
+
+   **v1.0 is a breaking release.** Every method now has an explicit version
+   suffix (e.g. ``foods_search_v5``). The unsuffixed names from 0.x remain
+   as deprecation aliases until v2.0. Run with
+   ``python -W default::DeprecationWarning:fatsecret`` to surface them.
+
 Installation
 ------------
 Install the module via pip::
@@ -41,7 +48,7 @@ Once you have created a session then you can start reading from Fatsecret's publ
 
 .. code-block:: python
 
-    foods = fs.foods_search("Tacos")
+    foods = fs.foods_search_v5("Tacos")        # latest upstream version
 
 OAuth Examples
 --------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,7 +1,49 @@
 .. _usage:
 
-OAuth Examples
-==============
+Migrating from 0.x
+==================
+
+In v1.0, every wrapper method has an explicit version suffix matching the
+upstream API:
+
+.. code-block:: python
+
+    # Before (0.x):
+    foods = fs.foods_search("Tacos")
+
+    # After (1.0):
+    foods = fs.foods_search_v5("Tacos")        # latest upstream
+    # or, to preserve the 0.x response shape exactly:
+    foods = fs.foods_search_v1("Tacos")
+
+The unsuffixed names still exist as deprecation aliases that delegate to
+their ``_v1`` replacements and will be removed in v2.0. To surface the
+warnings during development::
+
+    python -W default::DeprecationWarning:fatsecret
+
+OAuth2 (client-credentials)
+===========================
+
+Public, non-delegated endpoints (food search, food.get, recipes, plus the
+Native APIs and Premier-only methods) can be called via OAuth2 by passing
+``auth="oauth2"`` and the scopes you need:
+
+.. code-block:: python
+
+    from fatsecret import Fatsecret
+
+    fs = Fatsecret(
+        client_id,
+        client_secret,
+        auth="oauth2",
+        scopes=["basic", "premier", "image-recognition"],
+    )
+
+    foods = fs.foods_search_v5("Tacos")
+
+OAuth1 (3-legged) examples
+==========================
 
 Fatsecret supports 3-legged OAuth authentication. You can also authenticate to a profile that your application
 created.


### PR DESCRIPTION
## Summary

Final PR in the v1.0 series (#88, #89, #90 already merged). Sphinx-only
changes — no source impact.

- \`index.rst\` — prominent v1.0 breaking-change note + bumped quick example to \`foods_search_v5\`
- \`api.rst\` — leads with \`_vN\` convention, deprecation alias behavior, and the \`python -W default::DeprecationWarning:fatsecret\` hint above the autoclass directive
- \`usage.rst\` — new "Migrating from 0.x" section with old-vs-new code samples; new "OAuth2 (client-credentials)" example; original OAuth1 examples retained

No Sphinx config changes — existing autodoc setup picks up the new \`_vN\` methods and the \`.. deprecated::\` directives baked into wrapper docstrings.

## Test plan

- [ ] Lint clean (no source changes)
- [ ] \`make docs\` builds with zero WARNINGs
- [ ] Tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)