### PR TITLE
test: saturate endpoint test coverage to 98%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ coverage.xml
 # Environment files
 .env
 scripts/.cache/*.html
+
+# Local planning docs (numbered by phase, never committed)
+plans/

--- a/tests/unit/endpoints/test_classification.py
+++ b/tests/unit/endpoints/test_classification.py
@@ -1,0 +1,302 @@
+"""Exhaustive unit tests for the Food Classification resource.
+
+Covers the six method-version pairs (all Premier-only):
+  * food_brands.get          v1, v2
+  * food_categories.get      v1, v2
+  * food_sub_categories.get  v1, v2
+
+For each method-version we assert:
+  1. Happy path: correct `method=` value in params + unwrapped return shape.
+  2. Optional params: present when supplied, absent when None.
+  3. Single-dict response normalised to a list by `_unwrap`.
+  4. Empty / None response coerced to ``[]``.
+  5. ``PremierRequiredError`` raised by `_call` propagates to the caller.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret, PremierRequiredError
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+# ---------------------------------------------------------------------------
+# food_brands.get  (v1, v2)
+# ---------------------------------------------------------------------------
+
+BRANDS_VERSIONS = [
+    ("food_brands_get_v1", "food_brands.get"),
+    ("food_brands_get_v2", "food_brands.get.v2"),
+]
+
+
+@pytest.mark.parametrize("method_name,api_method", BRANDS_VERSIONS)
+def test_food_brands_get_happy_path(fs, method_name, api_method):
+    payload = {"food_brands": {"food_brand": ["Brand A", "Brand B"]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)("A")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert params["starts_with"] == "A"
+    # No optionals supplied → must NOT appear in params.
+    assert "brand_type" not in params
+    assert "region" not in params
+    assert "language" not in params
+    assert result == ["Brand A", "Brand B"]
+
+
+@pytest.mark.parametrize("method_name,api_method", BRANDS_VERSIONS)
+def test_food_brands_get_with_all_optionals(fs, method_name, api_method):
+    payload = {"food_brands": {"food_brand": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(
+            "B",
+            brand_type="manufacturer",
+            region="US",
+            language="en",
+        )
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert params["starts_with"] == "B"
+    assert params["brand_type"] == "manufacturer"
+    assert params["region"] == "US"
+    assert params["language"] == "en"
+
+
+@pytest.mark.parametrize("method_name,_api", BRANDS_VERSIONS)
+@pytest.mark.parametrize(
+    "kwarg,value",
+    [("brand_type", "manufacturer"), ("region", "US"), ("language", "en")],
+)
+def test_food_brands_get_each_optional_param_individually(
+    fs, method_name, _api, kwarg, value
+):
+    payload = {"food_brands": {"food_brand": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)("A", **{kwarg: value})
+    params = mock_call.call_args.args[0]
+    assert params[kwarg] == value
+    # Other optionals stay omitted.
+    others = {"brand_type", "region", "language"} - {kwarg}
+    for o in others:
+        assert o not in params
+
+
+@pytest.mark.parametrize("method_name,_api", BRANDS_VERSIONS)
+def test_food_brands_get_omits_optionals_when_none(fs, method_name, _api):
+    payload = {"food_brands": {"food_brand": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)("A", brand_type=None, region=None, language=None)
+    params = mock_call.call_args.args[0]
+    assert "brand_type" not in params
+    assert "region" not in params
+    assert "language" not in params
+
+
+@pytest.mark.parametrize("method_name,_api", BRANDS_VERSIONS)
+def test_food_brands_get_single_dict_coerced_to_list(fs, method_name, _api):
+    payload = {"food_brands": {"food_brand": "Solo Brand"}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)("S")
+    assert result == ["Solo Brand"]
+
+
+@pytest.mark.parametrize("method_name,_api", BRANDS_VERSIONS)
+@pytest.mark.parametrize("payload", [{}, {"food_brands": None}])
+def test_food_brands_get_empty_response_returns_empty_list(
+    fs, method_name, _api, payload
+):
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)("Z")
+    assert result == []
+
+
+@pytest.mark.parametrize("method_name,_api", BRANDS_VERSIONS)
+def test_food_brands_get_propagates_premier_required_error(fs, method_name, _api):
+    with patch.object(
+        Fatsecret, "_call", side_effect=PremierRequiredError(21, "Premier required")
+    ):
+        with pytest.raises(PremierRequiredError):
+            getattr(fs, method_name)("A")
+
+
+# ---------------------------------------------------------------------------
+# food_categories.get  (v1, v2)
+# ---------------------------------------------------------------------------
+
+CATEGORIES_VERSIONS = [
+    ("food_categories_get_v1", "food_categories.get"),
+    ("food_categories_get_v2", "food_categories.get.v2"),
+]
+
+
+@pytest.mark.parametrize("method_name,api_method", CATEGORIES_VERSIONS)
+def test_food_categories_get_happy_path(fs, method_name, api_method):
+    payload = {
+        "food_categories": {
+            "food_category": [
+                {"food_category_id": "1", "food_category_name": "Baked Foods"},
+                {"food_category_id": "2", "food_category_name": "Beverages"},
+            ]
+        }
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)()
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert "region" not in params
+    assert "language" not in params
+    assert result == [
+        {"food_category_id": "1", "food_category_name": "Baked Foods"},
+        {"food_category_id": "2", "food_category_name": "Beverages"},
+    ]
+
+
+@pytest.mark.parametrize("method_name,_api", CATEGORIES_VERSIONS)
+@pytest.mark.parametrize(
+    "kwarg,value", [("region", "US"), ("language", "en")]
+)
+def test_food_categories_get_optional_present_when_supplied(
+    fs, method_name, _api, kwarg, value
+):
+    payload = {"food_categories": {"food_category": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(**{kwarg: value})
+    params = mock_call.call_args.args[0]
+    assert params[kwarg] == value
+    other = "language" if kwarg == "region" else "region"
+    assert other not in params
+
+
+@pytest.mark.parametrize("method_name,_api", CATEGORIES_VERSIONS)
+def test_food_categories_get_optionals_absent_when_none(fs, method_name, _api):
+    payload = {"food_categories": {"food_category": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(region=None, language=None)
+    params = mock_call.call_args.args[0]
+    assert "region" not in params
+    assert "language" not in params
+
+
+@pytest.mark.parametrize("method_name,_api", CATEGORIES_VERSIONS)
+def test_food_categories_get_single_dict_coerced_to_list(fs, method_name, _api):
+    payload = {
+        "food_categories": {
+            "food_category": {"food_category_id": "1", "food_category_name": "Baked"}
+        }
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == [{"food_category_id": "1", "food_category_name": "Baked"}]
+
+
+@pytest.mark.parametrize("method_name,_api", CATEGORIES_VERSIONS)
+@pytest.mark.parametrize("payload", [{}, {"food_categories": None}])
+def test_food_categories_get_empty_response_returns_empty_list(
+    fs, method_name, _api, payload
+):
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == []
+
+
+@pytest.mark.parametrize("method_name,_api", CATEGORIES_VERSIONS)
+def test_food_categories_get_propagates_premier_required_error(fs, method_name, _api):
+    with patch.object(
+        Fatsecret, "_call", side_effect=PremierRequiredError(21, "Premier required")
+    ):
+        with pytest.raises(PremierRequiredError):
+            getattr(fs, method_name)()
+
+
+# ---------------------------------------------------------------------------
+# food_sub_categories.get  (v1, v2)
+# ---------------------------------------------------------------------------
+
+SUB_CATEGORIES_VERSIONS = [
+    ("food_sub_categories_get_v1", "food_sub_categories.get"),
+    ("food_sub_categories_get_v2", "food_sub_categories.get.v2"),
+]
+
+
+@pytest.mark.parametrize("method_name,api_method", SUB_CATEGORIES_VERSIONS)
+def test_food_sub_categories_get_happy_path(fs, method_name, api_method):
+    payload = {
+        "food_sub_categories": {
+            "food_sub_category": ["Breads", "Cakes", "Cookies"]
+        }
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)("1")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert params["food_category_id"] == "1"
+    assert "region" not in params
+    assert "language" not in params
+    assert result == ["Breads", "Cakes", "Cookies"]
+
+
+@pytest.mark.parametrize("method_name,_api", SUB_CATEGORIES_VERSIONS)
+@pytest.mark.parametrize(
+    "kwarg,value", [("region", "US"), ("language", "en")]
+)
+def test_food_sub_categories_get_optional_present_when_supplied(
+    fs, method_name, _api, kwarg, value
+):
+    payload = {"food_sub_categories": {"food_sub_category": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)("7", **{kwarg: value})
+    params = mock_call.call_args.args[0]
+    assert params["food_category_id"] == "7"
+    assert params[kwarg] == value
+    other = "language" if kwarg == "region" else "region"
+    assert other not in params
+
+
+@pytest.mark.parametrize("method_name,_api", SUB_CATEGORIES_VERSIONS)
+def test_food_sub_categories_get_optionals_absent_when_none(fs, method_name, _api):
+    payload = {"food_sub_categories": {"food_sub_category": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)("7", region=None, language=None)
+    params = mock_call.call_args.args[0]
+    assert "region" not in params
+    assert "language" not in params
+
+
+@pytest.mark.parametrize("method_name,_api", SUB_CATEGORIES_VERSIONS)
+def test_food_sub_categories_get_single_dict_coerced_to_list(fs, method_name, _api):
+    payload = {"food_sub_categories": {"food_sub_category": "Breads"}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)("1")
+    assert result == ["Breads"]
+
+
+@pytest.mark.parametrize("method_name,_api", SUB_CATEGORIES_VERSIONS)
+@pytest.mark.parametrize("payload", [{}, {"food_sub_categories": None}])
+def test_food_sub_categories_get_empty_response_returns_empty_list(
+    fs, method_name, _api, payload
+):
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)("1")
+    assert result == []
+
+
+@pytest.mark.parametrize("method_name,_api", SUB_CATEGORIES_VERSIONS)
+def test_food_sub_categories_get_propagates_premier_required_error(
+    fs, method_name, _api
+):
+    with patch.object(
+        Fatsecret, "_call", side_effect=PremierRequiredError(21, "Premier required")
+    ):
+        with pytest.raises(PremierRequiredError):
+            getattr(fs, method_name)("1")

--- a/tests/unit/endpoints/test_client_core.py
+++ b/tests/unit/endpoints/test_client_core.py
@@ -1,0 +1,393 @@
+"""Direct unit tests for client core internals not covered by endpoint tests.
+
+Covers:
+  * ``_call`` HTTP body (OAuth1 vs OAuth2 paths, defaults, copying, overrides)
+  * OAuth1 constructor with ``session_token`` arg
+  * ``api_url`` fallback when ``self.oauth`` is None (OAuth2 mode)
+  * ``_unwrap`` else branch when ``list_key`` doesn't match
+  * ``get_authorize_url`` HMAC-SHA1 signing flow
+  * Legacy ``valid_response`` response dispatcher (used only by food_get_v2)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret
+from fatsecret.errors import (
+    ApplicationError,
+    AuthenticationError,
+    GeneralError,
+    ParameterError,
+)
+
+
+# --------------------------- helpers ---------------------------
+
+
+def _make_oauth1_fs():
+    """OAuth1 Fatsecret with mocked OAuth1Service so no network occurs."""
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        mock_oauth1.return_value.base_url = Fatsecret.BASE_URL
+        mock_oauth1.return_value.request_token_url = Fatsecret.REQUEST_TOKEN_URL
+        mock_oauth1.return_value.authorize_url = Fatsecret.AUTHORIZE_URL
+        fs = Fatsecret("ck", "cs")
+    return fs
+
+
+def _make_oauth2_fs():
+    return Fatsecret("ck", "cs", auth="oauth2")
+
+
+def _fake_resp(payload):
+    resp = MagicMock()
+    resp.json = MagicMock(return_value=payload)
+    return resp
+
+
+# --------------------------- _call ---------------------------
+
+
+class TestCallHttpBody:
+    def test_oauth1_sends_no_authorization_header(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        result = fs._call({"method": "foo.get"})
+
+        assert result == {"ok": True}
+        kwargs = fs.session.request.call_args.kwargs
+        # OAuth1 path doesn't pass headers
+        assert "headers" not in kwargs or kwargs.get("headers") is None
+
+    def test_oauth2_sends_bearer_authorization_header(self):
+        fs = _make_oauth2_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        with patch.object(fs, "_get_oauth2_token", return_value="bearer-xyz") as tok:
+            fs._call({"method": "foo.get"})
+
+        tok.assert_called_once()
+        kwargs = fs.session.request.call_args.kwargs
+        assert kwargs["headers"] == {"Authorization": "Bearer bearer-xyz"}
+
+    def test_format_defaults_to_json(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        fs._call({"method": "foo.get"})
+
+        kwargs = fs.session.request.call_args.kwargs
+        assert kwargs["params"]["format"] == "json"
+
+    def test_format_not_overridden_when_provided(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        fs._call({"method": "foo.get", "format": "xml"})
+
+        kwargs = fs.session.request.call_args.kwargs
+        assert kwargs["params"]["format"] == "xml"
+
+    def test_params_is_copied_not_mutated(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        original = {"method": "foo.get"}
+        fs._call(original)
+
+        # caller's dict must not have been mutated with "format"
+        assert "format" not in original
+
+    def test_url_arg_overrides_api_url(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        custom_url = "https://platform.fatsecret.com/rest/foods/search/v1"
+        fs._call({"method": "ignored"}, url=custom_url)
+
+        args = fs.session.request.call_args.args
+        # method, target — target is positional
+        assert args[1] == custom_url
+
+    def test_default_target_is_api_url(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        fs._call({"method": "foo.get"})
+
+        args = fs.session.request.call_args.args
+        assert args[1] == fs.api_url
+
+    def test_json_body_passed_through(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        body = {"hello": "world"}
+        fs._call({"method": "foo.post"}, method="POST", json_body=body)
+
+        call = fs.session.request.call_args
+        assert call.kwargs["json"] is body
+        assert call.args[0] == "POST"
+
+    def test_method_defaults_to_get(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(return_value=_fake_resp({"ok": True}))
+
+        fs._call({"method": "foo.get"})
+        assert fs.session.request.call_args.args[0] == "GET"
+
+    def test_error_envelope_triggers_exception(self):
+        fs = _make_oauth1_fs()
+        fs.session = MagicMock()
+        fs.session.request = MagicMock(
+            return_value=_fake_resp({"error": {"code": 2, "message": "auth"}})
+        )
+
+        with pytest.raises(AuthenticationError):
+            fs._call({"method": "foo.get"})
+
+
+# --------------------------- OAuth1 session_token ---------------------------
+
+
+class TestOAuth1SessionToken:
+    def test_session_token_sets_access_credentials_and_session(self):
+        with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+            session_obj = MagicMock(name="rauth-session")
+            mock_oauth1.return_value.get_session.return_value = session_obj
+
+            fs = Fatsecret("ck", "cs", session_token=("tok-A", "sec-B"))
+
+            assert fs.access_token == "tok-A"
+            assert fs.access_token_secret == "sec-B"
+            # get_session called with the session_token tuple
+            mock_oauth1.return_value.get_session.assert_called_once_with(
+                token=("tok-A", "sec-B")
+            )
+            assert fs.session is session_obj
+
+
+# --------------------------- api_url fallback ---------------------------
+
+
+class TestApiUrlFallback:
+    def test_oauth2_api_url_returns_base_url(self):
+        fs = _make_oauth2_fs()
+        # fs.oauth is None in OAuth2 mode -> property falls back to BASE_URL
+        assert fs.oauth is None
+        assert fs.api_url == Fatsecret.BASE_URL
+
+
+# --------------------------- _unwrap else branch ---------------------------
+
+
+class TestUnwrapElseBranch:
+    def test_list_key_not_in_dict_treats_cur_as_inner(self):
+        # _unwrap walks to {"foods": [...]} — cur is now a list (not dict),
+        # so list_key="food" doesn't match (the isinstance(cur, dict) check
+        # is False) and inner = cur (the list itself).
+        payload = {"foods": [{"a": 1}, {"a": 2}]}
+        assert Fatsecret._unwrap(payload, "foods", list_key="food") == [
+            {"a": 1},
+            {"a": 2},
+        ]
+
+    def test_list_key_not_in_dict_with_dict_terminal(self):
+        # Terminal is a dict, but list_key not in it -> dict is wrapped as
+        # a single-element list (since inner is dict not list).
+        payload = {"foods": {"other_key": 1}}
+        result = Fatsecret._unwrap(payload, "foods", list_key="food")
+        assert result == [{"other_key": 1}]
+
+
+# --------------------------- get_authorize_url ---------------------------
+
+
+class TestGetAuthorizeUrl:
+    def test_signs_request_and_stores_request_token(self):
+        fs = _make_oauth1_fs()
+
+        fake_resp = MagicMock()
+        fake_resp.text = "oauth_token=req-token-XYZ&oauth_token_secret=req-secret-ABCD"
+        fake_resp.raise_for_status = MagicMock()
+
+        with patch(
+            "fatsecret.fatsecret.requests.post", return_value=fake_resp
+        ) as mock_post:
+            url = fs.get_authorize_url(callback_url="oob")
+
+        # POST was made to the request_token endpoint
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == Fatsecret.REQUEST_TOKEN_URL
+        # Signed params posted as form data
+        data = kwargs["data"]
+        assert data["oauth_consumer_key"] == "ck"
+        assert data["oauth_signature_method"] == "HMAC-SHA1"
+        assert data["oauth_callback"] == "oob"
+        assert data["oauth_version"] == "1.0"
+        assert "oauth_timestamp" in data
+        assert "oauth_nonce" in data
+        # HMAC signature is base64-encoded -> non-empty string
+        assert isinstance(data["oauth_signature"], str)
+        assert len(data["oauth_signature"]) > 0
+        # Content-Type form header
+        assert kwargs["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+
+        # Tokens stored
+        assert fs.request_token == "req-token-XYZ"
+        assert fs.request_token_secret == "req-secret-ABCD"
+
+        # Authorize URL contains the request token
+        assert url.startswith(Fatsecret.AUTHORIZE_URL)
+        assert "oauth_token=req-token-XYZ" in url
+
+    def test_custom_callback_url_is_signed(self):
+        fs = _make_oauth1_fs()
+        fake_resp = MagicMock()
+        fake_resp.text = "oauth_token=t&oauth_token_secret=s"
+        fake_resp.raise_for_status = MagicMock()
+
+        with patch(
+            "fatsecret.fatsecret.requests.post", return_value=fake_resp
+        ) as mock_post:
+            fs.get_authorize_url(callback_url="https://example.com/cb")
+
+        data = mock_post.call_args.kwargs["data"]
+        assert data["oauth_callback"] == "https://example.com/cb"
+
+
+# --------------------------- valid_response legacy ---------------------------
+
+
+def _resp(payload):
+    """Build a fake requests.Response with .json() returning ``payload``."""
+    r = MagicMock()
+    r.json = MagicMock(return_value=payload)
+    return r
+
+
+class TestValidResponseErrors:
+    def test_error_code_2_authentication(self):
+        with pytest.raises(AuthenticationError) as ei:
+            Fatsecret.valid_response(_resp({"error": {"code": 2, "message": "x"}}))
+        assert ei.value.code == 2
+
+    @pytest.mark.parametrize("code", [1, 10, 11, 12, 20, 21])
+    def test_error_general_range(self, code):
+        with pytest.raises(GeneralError) as ei:
+            Fatsecret.valid_response(_resp({"error": {"code": code, "message": "x"}}))
+        assert ei.value.code == code
+
+    @pytest.mark.parametrize("code", [3, 4, 5, 6, 7, 8, 9])
+    def test_error_auth_range(self, code):
+        with pytest.raises(AuthenticationError) as ei:
+            Fatsecret.valid_response(_resp({"error": {"code": code, "message": "x"}}))
+        assert ei.value.code == code
+
+    @pytest.mark.parametrize("code", [101, 102, 103, 104, 105, 106, 107, 108])
+    def test_error_parameter_range(self, code):
+        with pytest.raises(ParameterError) as ei:
+            Fatsecret.valid_response(_resp({"error": {"code": code, "message": "x"}}))
+        assert ei.value.code == code
+
+    @pytest.mark.parametrize("code", [201, 202, 203, 204, 205, 206, 207])
+    def test_error_application_range(self, code):
+        with pytest.raises(ApplicationError) as ei:
+            Fatsecret.valid_response(_resp({"error": {"code": code, "message": "x"}}))
+        assert ei.value.code == code
+
+
+class TestValidResponseBranches:
+    def test_success_returns_true(self):
+        assert Fatsecret.valid_response(_resp({"success": "1"})) is True
+
+    def test_foods_returns_food_inner(self):
+        assert Fatsecret.valid_response(_resp({"foods": {"food": [{"a": 1}]}})) == [
+            {"a": 1}
+        ]
+
+    def test_suggestions_returns_value(self):
+        assert Fatsecret.valid_response(_resp({"suggestions": ["apple", "bread"]})) == [
+            "apple",
+            "bread",
+        ]
+
+    def test_recipes_returns_recipe_inner(self):
+        assert Fatsecret.valid_response(
+            _resp({"recipes": {"recipe": [{"r": 1}]}})
+        ) == [{"r": 1}]
+
+    def test_saved_meals_returns_saved_meal_inner(self):
+        assert Fatsecret.valid_response(
+            _resp({"saved_meals": {"saved_meal": [{"m": 1}]}})
+        ) == [{"m": 1}]
+
+    def test_saved_meal_items_returns_saved_meal_item_inner(self):
+        assert Fatsecret.valid_response(
+            _resp({"saved_meal_items": {"saved_meal_item": [{"i": 1}]}})
+        ) == [{"i": 1}]
+
+    def test_exercise_types_returns_exercise_inner(self):
+        assert Fatsecret.valid_response(
+            _resp({"exercise_types": {"exercise": [{"e": 1}]}})
+        ) == [{"e": 1}]
+
+    def test_food_entries_none_returns_empty_list(self):
+        assert Fatsecret.valid_response(_resp({"food_entries": None})) == []
+
+    def test_food_entries_dict_coerced_to_list(self):
+        assert Fatsecret.valid_response(
+            _resp({"food_entries": {"food_entry": {"id": "1"}}})
+        ) == [{"id": "1"}]
+
+    def test_food_entries_list_returned_as_is(self):
+        assert Fatsecret.valid_response(
+            _resp({"food_entries": {"food_entry": [{"id": "1"}, {"id": "2"}]}})
+        ) == [{"id": "1"}, {"id": "2"}]
+
+    def test_month_returns_day_inner(self):
+        assert Fatsecret.valid_response(_resp({"month": {"day": [{"d": 1}]}})) == [
+            {"d": 1}
+        ]
+
+    def test_profile_with_auth_token_returns_tuple(self):
+        result = Fatsecret.valid_response(
+            _resp({"profile": {"auth_token": "tok", "auth_secret": "sec"}})
+        )
+        assert result == ("tok", "sec")
+
+    def test_profile_without_auth_token_returns_dict(self):
+        result = Fatsecret.valid_response(
+            _resp({"profile": {"user_id": "u1"}})
+        )
+        assert result == {"user_id": "u1"}
+
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            ("food", {"food_id": "1"}),
+            ("recipe", {"recipe_id": "2"}),
+            ("recipe_types", {"recipe_type": ["a", "b"]}),
+            ("saved_meal_id", "3"),
+            ("saved_meal_item_id", "4"),
+            ("food_entry_id", "5"),
+        ],
+    )
+    def test_bare_keys_returned_directly(self, key, value):
+        assert Fatsecret.valid_response(_resp({key: value})) == value
+
+    def test_empty_response_falls_through(self):
+        # Empty dict -> falsy json() -> returns None
+        assert Fatsecret.valid_response(_resp({})) is None

--- a/tests/unit/endpoints/test_diary.py
+++ b/tests/unit/endpoints/test_diary.py
@@ -1,0 +1,523 @@
+"""Exhaustive unit tests for Food Diary resource methods.
+
+Covers all 9 method-version pairs:
+    food_entry.create     v1
+    food_entry.edit       v1
+    food_entry.delete     v1
+    food_entries.get      v1, v2
+    food_entries.get_month v1, v2
+    food_entries.copy     v1
+    food_entries.copy_saved_meal v1
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+# ============================================================================
+# food_entry.create v1
+# ============================================================================
+
+
+def test_food_entry_create_v1_happy_path(fs):
+    payload = {"food_entries": {"food_entry": {"food_entry_id": "42"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_entry_create_v1(
+            food_id="1",
+            food_entry_name="Apple",
+            serving_id="s1",
+            number_of_units=1.5,
+            meal="breakfast",
+        )
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entry.create"
+    assert params["food_id"] == "1"
+    assert params["food_entry_name"] == "Apple"
+    assert params["serving_id"] == "s1"
+    assert params["number_of_units"] == 1.5
+    assert params["meal"] == "breakfast"
+    assert "date" not in params
+    assert mock_call.call_args.kwargs["method"] == "POST"
+    # _unwrap on food_entries with list_key=food_entry → list (single → coerced)
+    assert result == [{"food_entry_id": "42"}]
+
+
+def test_food_entry_create_v1_returns_new_food_entry_id(fs):
+    # The FS API returns `{"food_entry_id": {"value": "N"}}` on success;
+    # current implementation unwraps via food_entries→food_entry, so when the
+    # server returns a "food_entry_id" key directly, the helper returns it
+    # coerced as a single-element list.
+    payload = {"food_entry_id": {"value": "12345"}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.food_entry_create_v1(
+            food_id="1",
+            food_entry_name="Apple",
+            serving_id="s1",
+            number_of_units=1.0,
+            meal="lunch",
+        )
+    # _unwrap walks "food_entries" key which is absent → returns []
+    assert result == []
+
+
+def test_food_entry_create_v1_date_optional_omitted_when_none(fs):
+    payload = {"food_entries": {"food_entry": [{"food_entry_id": "1"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_entry_create_v1("1", "n", "s", 1.0, "dinner", date=None)
+    params = mock_call.call_args.args[0]
+    assert "date" not in params
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2020, 1, 15),
+        datetime.date(2020, 1, 15),
+        int(datetime.datetime(2020, 1, 15).timestamp()),
+        float(datetime.datetime(2020, 1, 15).timestamp()),
+    ],
+)
+def test_food_entry_create_v1_date_coercion(fs, value):
+    expected = Fatsecret.unix_time_v2(value)
+    payload = {"food_entries": {"food_entry": [{"food_entry_id": "1"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_entry_create_v1("1", "n", "s", 1.0, "snacks", date=value)
+    params = mock_call.call_args.args[0]
+    assert params["date"] == expected
+
+
+def test_food_entry_create_v1_empty_response_returns_empty_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = fs.food_entry_create_v1("1", "n", "s", 1.0, "breakfast")
+    assert result == []
+
+
+# ============================================================================
+# food_entry.edit v1
+# ============================================================================
+
+
+def test_food_entry_edit_v1_happy_path(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        result = fs.food_entry_edit_v1("fe1")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entry.edit"
+    assert params["food_entry_id"] == "fe1"
+    assert mock_call.call_args.kwargs["method"] == "PUT"
+    assert result is True
+
+
+def test_food_entry_edit_v1_all_optionals_present(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.food_entry_edit_v1(
+            "fe1",
+            food_entry_name="Pear",
+            serving_id="s9",
+            number_of_units=2.5,
+            meal="lunch",
+        )
+    params = mock_call.call_args.args[0]
+    assert params["food_entry_name"] == "Pear"
+    assert params["serving_id"] == "s9"
+    assert params["number_of_units"] == 2.5
+    assert params["meal"] == "lunch"
+
+
+def test_food_entry_edit_v1_omits_optionals_when_none(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.food_entry_edit_v1("fe1")
+    params = mock_call.call_args.args[0]
+    assert "food_entry_name" not in params
+    assert "serving_id" not in params
+    assert "number_of_units" not in params
+    assert "meal" not in params
+
+
+def test_food_entry_edit_v1_success_string(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": "1"}):
+        assert fs.food_entry_edit_v1("fe1") is True
+
+
+def test_food_entry_edit_v1_passes_through_non_success_payload(fs):
+    with patch.object(Fatsecret, "_call", return_value={"other": "data"}):
+        assert fs.food_entry_edit_v1("fe1") == {"other": "data"}
+
+
+# ============================================================================
+# food_entry.delete v1
+# ============================================================================
+
+
+def test_food_entry_delete_v1_happy_path(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        result = fs.food_entry_delete_v1("fe-9")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entry.delete"
+    assert params["food_entry_id"] == "fe-9"
+    assert mock_call.call_args.kwargs["method"] == "DELETE"
+    assert result is True
+
+
+def test_food_entry_delete_v1_success_zero_returns_false(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 0}):
+        assert fs.food_entry_delete_v1("fe-9") is False
+
+
+# ============================================================================
+# food_entries.get v1
+# ============================================================================
+
+
+def test_food_entries_get_v1_by_food_entry_id(fs):
+    payload = {"food_entries": {"food_entry": [{"food_entry_id": "10"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_entries_get_v1(food_entry_id="10")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entries.get"
+    assert params["food_entry_id"] == "10"
+    assert "date" not in params
+    # GET (no explicit HTTP method kwarg)
+    assert "method" not in mock_call.call_args.kwargs
+    assert result == [{"food_entry_id": "10"}]
+
+
+def test_food_entries_get_v1_by_date(fs):
+    payload = {"food_entries": {"food_entry": [{"food_entry_id": "20"}]}}
+    d = datetime.date(2021, 6, 1)
+    expected = Fatsecret.unix_time_v2(d)
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_entries_get_v1(date=d)
+    params = mock_call.call_args.args[0]
+    assert params["date"] == expected
+    assert "food_entry_id" not in params
+
+
+def test_food_entries_get_v1_single_dict_coerced_to_list(fs):
+    payload = {"food_entries": {"food_entry": {"food_entry_id": "10"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.food_entries_get_v1(food_entry_id="10")
+    assert result == [{"food_entry_id": "10"}]
+
+
+def test_food_entries_get_v1_no_args_short_circuits(fs):
+    with patch.object(Fatsecret, "_call") as mock_call:
+        assert fs.food_entries_get_v1() == []
+    mock_call.assert_not_called()
+
+
+def test_food_entries_get_v1_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.food_entries_get_v1(food_entry_id="x") == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2020, 1, 15),
+        datetime.date(2020, 1, 15),
+        int(datetime.datetime(2020, 1, 15).timestamp()),
+        float(datetime.datetime(2020, 1, 15).timestamp()),
+    ],
+)
+def test_food_entries_get_v1_date_coercion(fs, value):
+    expected = Fatsecret.unix_time_v2(value)
+    with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+        fs.food_entries_get_v1(date=value)
+    assert mock_call.call_args.args[0]["date"] == expected
+
+
+# ============================================================================
+# food_entries.get v2
+# ============================================================================
+
+
+def test_food_entries_get_v2_by_food_entry_id(fs):
+    payload = {"food_entries": {"food_entry": [{"food_entry_id": "55"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_entries_get_v2(food_entry_id="55")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entries.get.v2"
+    assert params["food_entry_id"] == "55"
+    assert result == [{"food_entry_id": "55"}]
+
+
+def test_food_entries_get_v2_by_date(fs):
+    d = datetime.datetime(2022, 3, 4)
+    expected = Fatsecret.unix_time_v2(d)
+    payload = {"food_entries": {"food_entry": [{"food_entry_id": "1"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_entries_get_v2(date=d)
+    params = mock_call.call_args.args[0]
+    assert params["date"] == expected
+
+
+def test_food_entries_get_v2_single_dict_coerced(fs):
+    payload = {"food_entries": {"food_entry": {"food_entry_id": "1"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.food_entries_get_v2(food_entry_id="1") == [{"food_entry_id": "1"}]
+
+
+def test_food_entries_get_v2_list_passthrough(fs):
+    payload = {"food_entries": {"food_entry": [{"food_entry_id": "1"}, {"food_entry_id": "2"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.food_entries_get_v2(food_entry_id="1")
+    assert result == [{"food_entry_id": "1"}, {"food_entry_id": "2"}]
+
+
+def test_food_entries_get_v2_no_args_short_circuits(fs):
+    with patch.object(Fatsecret, "_call") as mock_call:
+        assert fs.food_entries_get_v2() == []
+    mock_call.assert_not_called()
+
+
+def test_food_entries_get_v2_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.food_entries_get_v2(food_entry_id="x") == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2020, 1, 15),
+        datetime.date(2020, 1, 15),
+        int(datetime.datetime(2020, 1, 15).timestamp()),
+        float(datetime.datetime(2020, 1, 15).timestamp()),
+    ],
+)
+def test_food_entries_get_v2_date_coercion(fs, value):
+    expected = Fatsecret.unix_time_v2(value)
+    with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+        fs.food_entries_get_v2(date=value)
+    assert mock_call.call_args.args[0]["date"] == expected
+
+
+# ============================================================================
+# food_entries.get_month v1
+# ============================================================================
+
+
+def test_food_entries_get_month_v1_no_date(fs):
+    payload = {"month": {"day": [{"date_int": "1"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_entries_get_month_v1()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entries.get_month"
+    assert "date" not in params
+    assert result == [{"date_int": "1"}]
+
+
+def test_food_entries_get_month_v1_with_date(fs):
+    d = datetime.date(2020, 5, 1)
+    expected = Fatsecret.unix_time_v2(d)
+    payload = {"month": {"day": [{"date_int": "1"}, {"date_int": "2"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_entries_get_month_v1(date=d)
+    assert mock_call.call_args.args[0]["date"] == expected
+    assert result == [{"date_int": "1"}, {"date_int": "2"}]
+
+
+def test_food_entries_get_month_v1_single_day_coerced(fs):
+    payload = {"month": {"day": {"date_int": "1"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.food_entries_get_month_v1() == [{"date_int": "1"}]
+
+
+def test_food_entries_get_month_v1_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.food_entries_get_month_v1() == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2020, 1, 15),
+        datetime.date(2020, 1, 15),
+        int(datetime.datetime(2020, 1, 15).timestamp()),
+        float(datetime.datetime(2020, 1, 15).timestamp()),
+    ],
+)
+def test_food_entries_get_month_v1_date_coercion(fs, value):
+    expected = Fatsecret.unix_time_v2(value)
+    with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+        fs.food_entries_get_month_v1(date=value)
+    assert mock_call.call_args.args[0]["date"] == expected
+
+
+# ============================================================================
+# food_entries.get_month v2
+# ============================================================================
+
+
+def test_food_entries_get_month_v2_no_date(fs):
+    payload = {"month": {"day": [{"date_int": "1"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_entries_get_month_v2()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entries.get_month.v2"
+    assert "date" not in params
+    assert result == [{"date_int": "1"}]
+
+
+def test_food_entries_get_month_v2_with_date(fs):
+    d = datetime.datetime(2023, 2, 1)
+    expected = Fatsecret.unix_time_v2(d)
+    payload = {"month": {"day": [{"date_int": "1"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_entries_get_month_v2(date=d)
+    assert mock_call.call_args.args[0]["date"] == expected
+
+
+def test_food_entries_get_month_v2_single_day_coerced(fs):
+    payload = {"month": {"day": {"date_int": "1"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.food_entries_get_month_v2() == [{"date_int": "1"}]
+
+
+def test_food_entries_get_month_v2_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.food_entries_get_month_v2() == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2020, 1, 15),
+        datetime.date(2020, 1, 15),
+        int(datetime.datetime(2020, 1, 15).timestamp()),
+        float(datetime.datetime(2020, 1, 15).timestamp()),
+    ],
+)
+def test_food_entries_get_month_v2_date_coercion(fs, value):
+    expected = Fatsecret.unix_time_v2(value)
+    with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+        fs.food_entries_get_month_v2(date=value)
+    assert mock_call.call_args.args[0]["date"] == expected
+
+
+# ============================================================================
+# food_entries.copy v1
+# ============================================================================
+
+
+def test_food_entries_copy_v1_happy_path(fs):
+    from_d = datetime.date(2024, 1, 1)
+    to_d = datetime.date(2024, 1, 2)
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        result = fs.food_entries_copy_v1(from_d, to_d)
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entries.copy"
+    assert params["from_date"] == Fatsecret.unix_time_v2(from_d)
+    assert params["to_date"] == Fatsecret.unix_time_v2(to_d)
+    assert "meal" not in params
+    assert mock_call.call_args.kwargs["method"] == "POST"
+    assert result is True
+
+
+def test_food_entries_copy_v1_with_meal(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.food_entries_copy_v1(0, 1, meal="lunch")
+    assert mock_call.call_args.args[0]["meal"] == "lunch"
+
+
+def test_food_entries_copy_v1_meal_none_omitted(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.food_entries_copy_v1(0, 1, meal=None)
+    assert "meal" not in mock_call.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2020, 1, 15),
+        datetime.date(2020, 1, 15),
+        int(datetime.datetime(2020, 1, 15).timestamp()),
+        float(datetime.datetime(2020, 1, 15).timestamp()),
+    ],
+)
+def test_food_entries_copy_v1_from_date_coercion(fs, value):
+    expected = Fatsecret.unix_time_v2(value)
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.food_entries_copy_v1(value, 0)
+    assert mock_call.call_args.args[0]["from_date"] == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2020, 1, 15),
+        datetime.date(2020, 1, 15),
+        int(datetime.datetime(2020, 1, 15).timestamp()),
+        float(datetime.datetime(2020, 1, 15).timestamp()),
+    ],
+)
+def test_food_entries_copy_v1_to_date_coercion(fs, value):
+    expected = Fatsecret.unix_time_v2(value)
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.food_entries_copy_v1(0, value)
+    assert mock_call.call_args.args[0]["to_date"] == expected
+
+
+def test_food_entries_copy_v1_success_zero_returns_false(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 0}):
+        assert fs.food_entries_copy_v1(0, 1) is False
+
+
+# ============================================================================
+# food_entries.copy_saved_meal v1
+# ============================================================================
+
+
+def test_food_entries_copy_saved_meal_v1_happy_path(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        result = fs.food_entries_copy_saved_meal_v1("sm-1", "dinner")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food_entries.copy_saved_meal"
+    assert params["saved_meal_id"] == "sm-1"
+    assert params["meal"] == "dinner"
+    assert "date" not in params
+    assert mock_call.call_args.kwargs["method"] == "POST"
+    assert result is True
+
+
+def test_food_entries_copy_saved_meal_v1_date_none_omitted(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.food_entries_copy_saved_meal_v1("sm-1", "dinner", date=None)
+    assert "date" not in mock_call.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2020, 1, 15),
+        datetime.date(2020, 1, 15),
+        int(datetime.datetime(2020, 1, 15).timestamp()),
+        float(datetime.datetime(2020, 1, 15).timestamp()),
+    ],
+)
+def test_food_entries_copy_saved_meal_v1_date_coercion(fs, value):
+    expected = Fatsecret.unix_time_v2(value)
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.food_entries_copy_saved_meal_v1("sm-1", "dinner", date=value)
+    assert mock_call.call_args.args[0]["date"] == expected
+
+
+def test_food_entries_copy_saved_meal_v1_success_zero_returns_false(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 0}):
+        assert fs.food_entries_copy_saved_meal_v1("sm", "lunch") is False
+
+
+def test_food_entries_copy_saved_meal_v1_success_string(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": "1"}):
+        assert fs.food_entries_copy_saved_meal_v1("sm", "lunch") is True

--- a/tests/unit/endpoints/test_exercises.py
+++ b/tests/unit/endpoints/test_exercises.py
@@ -1,0 +1,394 @@
+"""Exhaustive unit tests for the Exercise resource (9 method-version pairs).
+
+Covers:
+- exercises.get v1, v2
+- exercise_entries.get v1, v2
+- exercise_entries.get_month v1, v2
+- exercise_entry.edit v1
+- exercise_entries.commit_day v1
+- exercise_entries.save_template v1
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+# Reference date: 2021-06-15 -> 18793 days since epoch.
+REF_DT = datetime.datetime(2021, 6, 15)
+REF_DATE = datetime.date(2021, 6, 15)
+REF_TS = int(REF_DT.replace(tzinfo=datetime.timezone.utc).timestamp())
+REF_DAYS = (REF_DT - datetime.datetime(1970, 1, 1)).days
+
+
+# --------------------------- exercises.get v1 / v2 ---------------------------
+
+
+def test_exercises_get_v1_happy_path_minimal(fs):
+    payload = {"exercise_types": {"exercise": [{"name": "Running"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercises_get_v1()
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "exercises.get"
+    # GET is the default in _call -> no `method=` kwarg expected.
+    assert mock_call.call_args.kwargs.get("method") in (None, "GET")
+    assert "region" not in params and "language" not in params
+    assert result == [{"name": "Running"}]
+
+
+def test_exercises_get_v1_premier_params_propagated(fs):
+    """exercises.get carries the Premier-exclusive region/language params."""
+    payload = {"exercise_types": {"exercise": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.exercises_get_v1(region="US", language="en")
+    params = mock_call.call_args.args[0]
+    assert params["region"] == "US"
+    assert params["language"] == "en"
+
+
+def test_exercises_get_v1_single_dict_coerced_to_list(fs):
+    payload = {"exercise_types": {"exercise": {"name": "Running"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.exercises_get_v1()
+    assert result == [{"name": "Running"}]
+
+
+def test_exercises_get_v1_empty_returns_empty_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = fs.exercises_get_v1()
+    assert result == []
+
+
+def test_exercises_get_v2_happy_path(fs):
+    payload = {"exercise_types": {"exercise": [{"name": "Cycling"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercises_get_v2()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "exercises.get.v2"
+    assert "region" not in params and "language" not in params
+    assert result == [{"name": "Cycling"}]
+
+
+def test_exercises_get_v2_premier_params_propagated(fs):
+    payload = {"exercise_types": {"exercise": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.exercises_get_v2(region="GB", language="fr")
+    params = mock_call.call_args.args[0]
+    assert params["region"] == "GB"
+    assert params["language"] == "fr"
+
+
+def test_exercises_get_v2_empty_returns_empty_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.exercises_get_v2() == []
+
+
+# --------------------------- exercise_entries.get v1 / v2 ---------------------------
+
+
+def _date_calls_identical(fs, fn):
+    """Helper: assert datetime/date/int/float produce the same params."""
+    results = []
+    for d in (REF_DT, REF_DATE, REF_TS, float(REF_TS)):
+        with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+            fn(date=d)
+        results.append(mock_call.call_args.args[0])
+    # All must be equal
+    for r in results[1:]:
+        assert r == results[0]
+    # And date must equal REF_DAYS
+    assert results[0]["date"] == REF_DAYS
+
+
+def test_exercise_entries_get_v1_happy_path_no_date(fs):
+    payload = {
+        "exercise_entries": {"exercise_entry": [{"exercise_entry_id": "1"}]}
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercise_entries_get_v1()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "exercise_entries.get"
+    assert "date" not in params
+    assert mock_call.call_args.kwargs.get("method") in (None, "GET")
+    assert result == [{"exercise_entry_id": "1"}]
+
+
+def test_exercise_entries_get_v1_with_date(fs):
+    with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+        fs.exercise_entries_get_v1(date=REF_DT)
+    params = mock_call.call_args.args[0]
+    assert params["date"] == REF_DAYS
+
+
+def test_exercise_entries_get_v1_date_coercion(fs):
+    _date_calls_identical(fs, fs.exercise_entries_get_v1)
+
+
+def test_exercise_entries_get_v1_single_dict_coerced(fs):
+    payload = {"exercise_entries": {"exercise_entry": {"exercise_entry_id": "9"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.exercise_entries_get_v1()
+    assert result == [{"exercise_entry_id": "9"}]
+
+
+def test_exercise_entries_get_v1_empty_returns_empty_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.exercise_entries_get_v1() == []
+
+
+def test_exercise_entries_get_v2_happy_path(fs):
+    payload = {
+        "exercise_entries": {
+            "exercise_entry": [{"exercise_entry_id": "1"}, {"exercise_entry_id": "2"}]
+        }
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercise_entries_get_v2()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "exercise_entries.get.v2"
+    assert "date" not in params
+    assert result == [{"exercise_entry_id": "1"}, {"exercise_entry_id": "2"}]
+
+
+def test_exercise_entries_get_v2_with_date(fs):
+    with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+        fs.exercise_entries_get_v2(date=REF_DATE)
+    params = mock_call.call_args.args[0]
+    assert params["date"] == REF_DAYS
+
+
+def test_exercise_entries_get_v2_date_coercion(fs):
+    _date_calls_identical(fs, fs.exercise_entries_get_v2)
+
+
+def test_exercise_entries_get_v2_single_dict_coerced(fs):
+    payload = {"exercise_entries": {"exercise_entry": {"exercise_entry_id": "9"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.exercise_entries_get_v2() == [{"exercise_entry_id": "9"}]
+
+
+def test_exercise_entries_get_v2_empty_returns_empty_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.exercise_entries_get_v2() == []
+
+
+# --------------------------- exercise_entries.get_month v1 / v2 ---------------------------
+
+
+def test_exercise_entries_get_month_v1_happy_path_no_date(fs):
+    payload = {"month": {"day": [{"date_int": "1"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercise_entries_get_month_v1()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "exercise_entries.get_month"
+    assert "date" not in params
+    assert mock_call.call_args.kwargs.get("method") in (None, "GET")
+    assert result == [{"date_int": "1"}]
+
+
+def test_exercise_entries_get_month_v1_with_date(fs):
+    with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+        fs.exercise_entries_get_month_v1(date=REF_DT)
+    assert mock_call.call_args.args[0]["date"] == REF_DAYS
+
+
+def test_exercise_entries_get_month_v1_date_coercion(fs):
+    _date_calls_identical(fs, fs.exercise_entries_get_month_v1)
+
+
+def test_exercise_entries_get_month_v1_single_day_coerced(fs):
+    payload = {"month": {"day": {"date_int": "1"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.exercise_entries_get_month_v1() == [{"date_int": "1"}]
+
+
+def test_exercise_entries_get_month_v1_empty_returns_empty(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.exercise_entries_get_month_v1() == []
+
+
+def test_exercise_entries_get_month_v2_happy_path(fs):
+    payload = {"month": {"day": [{"date_int": "1"}, {"date_int": "2"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercise_entries_get_month_v2()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "exercise_entries.get_month.v2"
+    assert "date" not in params
+    assert result == [{"date_int": "1"}, {"date_int": "2"}]
+
+
+def test_exercise_entries_get_month_v2_with_date(fs):
+    with patch.object(Fatsecret, "_call", return_value={}) as mock_call:
+        fs.exercise_entries_get_month_v2(date=REF_DATE)
+    assert mock_call.call_args.args[0]["date"] == REF_DAYS
+
+
+def test_exercise_entries_get_month_v2_date_coercion(fs):
+    _date_calls_identical(fs, fs.exercise_entries_get_month_v2)
+
+
+def test_exercise_entries_get_month_v2_single_day_coerced(fs):
+    payload = {"month": {"day": {"date_int": "1"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.exercise_entries_get_month_v2() == [{"date_int": "1"}]
+
+
+def test_exercise_entries_get_month_v2_empty_returns_empty(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.exercise_entries_get_month_v2() == []
+
+
+# --------------------------- exercise_entry.edit v1 ---------------------------
+
+
+def test_exercise_entry_edit_v1_happy_path_required_only(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercise_entry_edit_v1(
+            shift_to_id="11", shift_from_id="22", minutes=30
+        )
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "exercise_entry.edit"
+    assert params["shift_to_id"] == "11"
+    assert params["shift_from_id"] == "22"
+    assert params["minutes"] == 30
+    # Optional params absent when not supplied
+    for key in ("date", "shift_to_name", "shift_from_name", "kcal"):
+        assert key not in params
+    assert mock_call.call_args.kwargs.get("method") == "PUT"
+    assert result is True
+
+
+def test_exercise_entry_edit_v1_all_optional_params_present(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.exercise_entry_edit_v1(
+            shift_to_id="11",
+            shift_from_id="22",
+            minutes=15,
+            date=REF_DT,
+            shift_to_name="Running",
+            shift_from_name="Walking",
+            kcal=250,
+        )
+    params = mock_call.call_args.args[0]
+    assert params["date"] == REF_DAYS
+    assert params["shift_to_name"] == "Running"
+    assert params["shift_from_name"] == "Walking"
+    assert params["kcal"] == 250
+
+
+def test_exercise_entry_edit_v1_date_coercion(fs):
+    results = []
+    for d in (REF_DT, REF_DATE, REF_TS, float(REF_TS)):
+        with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+            fs.exercise_entry_edit_v1(
+                shift_to_id="11", shift_from_id="22", minutes=10, date=d
+            )
+        results.append(mock_call.call_args.args[0])
+    for r in results[1:]:
+        assert r == results[0]
+    assert results[0]["date"] == REF_DAYS
+
+
+def test_exercise_entry_edit_v1_mutator_returns_true(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}):
+        assert (
+            fs.exercise_entry_edit_v1(shift_to_id="1", shift_from_id="2", minutes=5)
+            is True
+        )
+
+
+# --------------------------- exercise_entries.commit_day v1 ---------------------------
+
+
+def test_exercise_entries_commit_day_v1_happy_path_no_date(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercise_entries_commit_day_v1()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "exercise_entries.commit_day"
+    assert "date" not in params
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    assert result is True
+
+
+def test_exercise_entries_commit_day_v1_with_date(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.exercise_entries_commit_day_v1(date=REF_DT)
+    assert mock_call.call_args.args[0]["date"] == REF_DAYS
+
+
+def test_exercise_entries_commit_day_v1_date_coercion(fs):
+    results = []
+    for d in (REF_DT, REF_DATE, REF_TS, float(REF_TS)):
+        with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+            fs.exercise_entries_commit_day_v1(date=d)
+        results.append(mock_call.call_args.args[0])
+    for r in results[1:]:
+        assert r == results[0]
+    assert results[0]["date"] == REF_DAYS
+
+
+def test_exercise_entries_commit_day_v1_mutator_returns_true(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}):
+        assert fs.exercise_entries_commit_day_v1() is True
+
+
+# --------------------------- exercise_entries.save_template v1 ---------------------------
+
+
+def test_exercise_entries_save_template_v1_happy_path_required_only(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.exercise_entries_save_template_v1(days=3)
+    params = mock_call.call_args.args[0]
+    # Critical: assert the legacy copy/paste bug is fixed.
+    assert params["method"] == "exercise_entries.save_template"
+    assert params["method"] != "exercise_entries.get_month"
+    assert params["days"] == 3
+    assert "date" not in params
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    assert result is True
+
+
+def test_exercise_entries_save_template_v1_with_date(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.exercise_entries_save_template_v1(days=7, date=REF_DT)
+    params = mock_call.call_args.args[0]
+    assert params["date"] == REF_DAYS
+    assert params["days"] == 7
+
+
+def test_exercise_entries_save_template_v1_days_coerced_to_int(fs):
+    """`days` is forced through int() in the source."""
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.exercise_entries_save_template_v1(days="5")  # type: ignore[arg-type]
+    assert mock_call.call_args.args[0]["days"] == 5
+
+
+def test_exercise_entries_save_template_v1_date_coercion(fs):
+    results = []
+    for d in (REF_DT, REF_DATE, REF_TS, float(REF_TS)):
+        with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+            fs.exercise_entries_save_template_v1(days=1, date=d)
+        results.append(mock_call.call_args.args[0])
+    for r in results[1:]:
+        assert r == results[0]
+    assert results[0]["date"] == REF_DAYS
+
+
+def test_exercise_entries_save_template_v1_mutator_returns_true(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}):
+        assert fs.exercise_entries_save_template_v1(days=1) is True

--- a/tests/unit/endpoints/test_foods.py
+++ b/tests/unit/endpoints/test_foods.py
@@ -1,0 +1,424 @@
+"""Exhaustive unit tests for the Foods resource.
+
+Covers fourteen method-version pairs:
+
+  * foods.search                v1, v2, v3, v4, v5
+  * food.get                    v1, v2, v3, v4, v5
+  * foods.autocomplete          v1, v2          (Premier)
+  * food.find_id_for_barcode    v1, v2          (Premier "barcode" scope)
+
+For each pair we assert:
+  1. Happy path: correct ``method=`` value in the params dict handed to
+     ``Fatsecret._call`` (or to ``session.get`` for the legacy ``food.get.v2``).
+  2. Required params propagated.
+  3. Every optional parameter is forwarded when supplied AND absent when
+     ``None`` (parametrized).
+  4. ``_unwrap`` list-coercion: a payload whose inner key is a single dict is
+     turned into ``[dict]``.
+  5. Empty response: list-returning methods return ``[]``, object-returning
+     methods return ``None`` or ``{}``.
+  6. Premier propagation: ``PremierRequiredError`` raised inside ``_call``
+     bubbles up unchanged.
+  7. ``foods_search_v5``'s ``food_type`` enum (none|generic|brand) passes
+     through as a raw string.
+
+``_call`` and ``_unwrap`` themselves are tested elsewhere; we always mock
+``_call`` so no HTTP is exercised.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret
+from fatsecret.errors import PremierRequiredError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+# ---------------------------------------------------------------------------
+# foods.search v1 - v5
+# ---------------------------------------------------------------------------
+
+
+SEARCH_METHOD_NAMES = {
+    1: "foods.search",
+    2: "foods.search.v2",
+    3: "foods.search.v3",
+    4: "foods.search.v4",
+    5: "foods.search.v5",
+}
+
+
+def _search_payload_v1(items):
+    return {"foods": {"food": items}}
+
+
+def _search_payload_v2plus(items):
+    # v2..v5 share the same unwrap path: foods_search -> results -> food
+    return {"foods_search": {"results": {"food": items}, "max_results": "10"}}
+
+
+def _call_search(fs, version, **kwargs):
+    return getattr(fs, f"foods_search_v{version}")("apple", **kwargs)
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
+def test_foods_search_happy_path(fs, version):
+    items = [{"food_id": "1"}, {"food_id": "2"}]
+    payload = _search_payload_v1(items) if version == 1 else _search_payload_v2plus(items)
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = _call_search(fs, version)
+
+    mock_call.assert_called_once()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == SEARCH_METHOD_NAMES[version]
+    assert params["search_expression"] == "apple"
+    # GET methods don't override _call's default `method` kwarg.
+    assert mock_call.call_args.kwargs.get("method", "GET") == "GET"
+    assert mock_call.call_args.kwargs.get("url") is None
+    assert mock_call.call_args.kwargs.get("json_body") is None
+    assert result == items
+
+
+# Optional-parameter forwarding. Each pair = (kwarg_name, sample_value, supported_versions).
+_SEARCH_OPTIONALS = [
+    ("page_number", 0, {1, 2, 3, 4, 5}),
+    ("max_results", 25, {1, 2, 3, 4, 5}),
+    ("generic_description", "Apple", {1}),
+    ("include_sub_categories", True, {2, 3, 4, 5}),
+    ("include_food_images", True, {3, 4, 5}),
+    ("include_food_attributes", True, {3, 4, 5}),
+    ("flag_default_serving", True, {2, 3, 4, 5}),
+    ("food_type", "brand", {5}),
+    ("region", "US", {1, 2, 3, 4, 5}),
+    ("language", "en", {1, 2, 3, 4, 5}),
+]
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("kwarg,value,supported", _SEARCH_OPTIONALS)
+def test_foods_search_optional_forwarding(fs, version, kwarg, value, supported):
+    if version not in supported:
+        pytest.skip(f"{kwarg} not supported on v{version}")
+    payload = _search_payload_v1([]) if version == 1 else _search_payload_v2plus([])
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        _call_search(fs, version, **{kwarg: value})
+    params = mock_call.call_args.args[0]
+    assert params[kwarg] == value
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
+def test_foods_search_optionals_absent_when_none(fs, version):
+    payload = _search_payload_v1([]) if version == 1 else _search_payload_v2plus([])
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        _call_search(fs, version)
+    params = mock_call.call_args.args[0]
+    # None of the optional keys should appear when the caller passed nothing.
+    for kwarg, _value, supported in _SEARCH_OPTIONALS:
+        if version in supported:
+            assert kwarg not in params, f"{kwarg} leaked into params on v{version}"
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
+def test_foods_search_single_dict_coerced_to_list(fs, version):
+    single = {"food_id": "42"}
+    payload = _search_payload_v1(single) if version == 1 else _search_payload_v2plus(single)
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert _call_search(fs, version) == [single]
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
+def test_foods_search_empty_response(fs, version):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert _call_search(fs, version) == []
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
+def test_foods_search_null_inner(fs, version):
+    payload = {"foods": None} if version == 1 else {"foods_search": {"results": None}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert _call_search(fs, version) == []
+
+
+@pytest.mark.parametrize("version", [2, 3, 4, 5])  # v2+ are Premier
+def test_foods_search_premier_propagates(fs, version):
+    with patch.object(
+        Fatsecret,
+        "_call",
+        side_effect=PremierRequiredError(207, "Premier required"),
+    ):
+        with pytest.raises(PremierRequiredError):
+            _call_search(fs, version)
+
+
+@pytest.mark.parametrize("food_type", ["none", "generic", "brand"])
+def test_foods_search_v5_food_type_enum_passthrough(fs, food_type):
+    payload = _search_payload_v2plus([])
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.foods_search_v5("apple", food_type=food_type)
+    assert mock_call.call_args.args[0]["food_type"] == food_type
+
+
+# ---------------------------------------------------------------------------
+# food.get v1 - v5
+# ---------------------------------------------------------------------------
+
+
+GET_METHOD_NAMES = {
+    1: "food.get",
+    2: "food.get.v2",
+    3: "food.get.v3",
+    4: "food.get.v4",
+    5: "food.get.v5",
+}
+
+
+# Optional kwarg, sample value, supported version set.
+_GET_OPTIONALS = [
+    ("include_sub_categories", True, {1, 3, 4, 5}),
+    ("flag_default_serving", True, {1, 3, 4, 5}),
+    ("include_food_images", True, {4, 5}),
+    ("include_food_attributes", True, {4, 5}),
+    ("region", "US", {1, 2, 3, 4, 5}),
+    ("language", "en", {1, 2, 3, 4, 5}),
+]
+
+
+# `food_get_v2` is a legacy method: it uses `session.get` + `valid_response`
+# directly, rather than `_call`. We test it with a session-level mock.
+
+
+def _mock_session_response(json_data):
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    return resp
+
+
+@pytest.mark.parametrize("version", [1, 3, 4, 5])
+def test_food_get_happy_path(fs, version):
+    food_obj = {"food_id": str(version), "food_name": f"Food v{version}"}
+    payload = {"food": food_obj}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, f"food_get_v{version}")("abc")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == GET_METHOD_NAMES[version]
+    assert params["food_id"] == "abc"
+    assert mock_call.call_args.kwargs.get("method", "GET") == "GET"
+    assert result == food_obj
+
+
+def test_food_get_v2_happy_path(fs):
+    food_obj = {"food_id": "2", "food_name": "Food v2"}
+    fs.session.get = MagicMock(return_value=_mock_session_response({"food": food_obj}))
+    result = fs.food_get_v2("abc")
+
+    fs.session.get.assert_called_once()
+    params = fs.session.get.call_args.kwargs["params"]
+    assert params["method"] == "food.get.v2"
+    assert params["food_id"] == "abc"
+    assert params["format"] == "json"
+    assert "region" not in params
+    assert "language" not in params
+    assert result == food_obj
+
+
+def test_food_get_v2_optional_forwarding(fs):
+    fs.session.get = MagicMock(return_value=_mock_session_response({"food": {}}))
+    fs.food_get_v2("x", region="US", language="en")
+    params = fs.session.get.call_args.kwargs["params"]
+    assert params["region"] == "US"
+    assert params["language"] == "en"
+
+
+@pytest.mark.parametrize("version", [1, 3, 4, 5])
+@pytest.mark.parametrize("kwarg,value,supported", _GET_OPTIONALS)
+def test_food_get_optional_forwarding(fs, version, kwarg, value, supported):
+    if version not in supported:
+        pytest.skip(f"{kwarg} not supported on v{version}")
+    with patch.object(Fatsecret, "_call", return_value={"food": {}}) as mock_call:
+        getattr(fs, f"food_get_v{version}")("abc", **{kwarg: value})
+    params = mock_call.call_args.args[0]
+    assert params[kwarg] == value
+
+
+@pytest.mark.parametrize("version", [1, 3, 4, 5])
+def test_food_get_optionals_absent_when_none(fs, version):
+    with patch.object(Fatsecret, "_call", return_value={"food": {}}) as mock_call:
+        getattr(fs, f"food_get_v{version}")("abc")
+    params = mock_call.call_args.args[0]
+    for kwarg, _value, supported in _GET_OPTIONALS:
+        if version in supported:
+            assert kwarg not in params
+
+
+@pytest.mark.parametrize("version", [1, 3, 4, 5])
+def test_food_get_empty_response(fs, version):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        # `_unwrap(payload, "food")` returns None when key missing.
+        assert getattr(fs, f"food_get_v{version}")("abc") is None
+
+
+# ---------------------------------------------------------------------------
+# foods.autocomplete v1, v2
+# ---------------------------------------------------------------------------
+
+
+AUTOCOMPLETE_METHOD_NAMES = {1: "foods.autocomplete", 2: "foods.autocomplete.v2"}
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_foods_autocomplete_happy_path(fs, version):
+    payload = {"suggestions": {"suggestion": ["apple", "apricot"]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, f"foods_autocomplete_v{version}")("ap")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == AUTOCOMPLETE_METHOD_NAMES[version]
+    assert params["expression"] == "ap"
+    assert "max_results" not in params
+    assert "region" not in params
+    assert result == ["apple", "apricot"]
+
+
+@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.parametrize(
+    "kwarg,value",
+    [("max_results", 10), ("region", "US")],
+)
+def test_foods_autocomplete_optional_forwarding(fs, version, kwarg, value):
+    payload = {"suggestions": {"suggestion": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, f"foods_autocomplete_v{version}")("ap", **{kwarg: value})
+    assert mock_call.call_args.args[0][kwarg] == value
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_foods_autocomplete_single_string_coerced_to_list(fs, version):
+    payload = {"suggestions": {"suggestion": "apple"}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert getattr(fs, f"foods_autocomplete_v{version}")("ap") == ["apple"]
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_foods_autocomplete_empty_response(fs, version):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert getattr(fs, f"foods_autocomplete_v{version}")("ap") == []
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_foods_autocomplete_premier_propagates(fs, version):
+    with patch.object(
+        Fatsecret,
+        "_call",
+        side_effect=PremierRequiredError(207, "Premier required"),
+    ):
+        with pytest.raises(PremierRequiredError):
+            getattr(fs, f"foods_autocomplete_v{version}")("ap")
+
+
+# ---------------------------------------------------------------------------
+# food.find_id_for_barcode v1, v2
+# ---------------------------------------------------------------------------
+
+
+BARCODE_METHOD_NAMES = {1: "food.find_id_for_barcode", 2: "food.find_id_for_barcode.v2"}
+
+
+def test_food_find_id_for_barcode_v1_happy_path(fs):
+    payload = {"food_id": {"value": "12345"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_find_id_for_barcode_v1("0049000028911")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == BARCODE_METHOD_NAMES[1]
+    assert params["barcode"] == "0049000028911"
+    assert "region" not in params
+    assert "language" not in params
+    assert result == {"value": "12345"}
+
+
+@pytest.mark.parametrize(
+    "kwarg,value",
+    [("region", "US"), ("language", "en")],
+)
+def test_food_find_id_for_barcode_v1_optional_forwarding(fs, kwarg, value):
+    payload = {"food_id": {"value": "0"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_find_id_for_barcode_v1("0049000028911", **{kwarg: value})
+    assert mock_call.call_args.args[0][kwarg] == value
+
+
+def test_food_find_id_for_barcode_v1_no_match_returns_zero_envelope(fs):
+    payload = {"food_id": {"value": "0"}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.food_find_id_for_barcode_v1("0000000000000") == {"value": "0"}
+
+
+def test_food_find_id_for_barcode_v1_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.food_find_id_for_barcode_v1("0000000000000") is None
+
+
+def test_food_find_id_for_barcode_v2_happy_path(fs):
+    food_obj = {"food_id": "12345", "food_name": "Coke 12oz"}
+    payload = {"food": food_obj}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_find_id_for_barcode_v2("0049000028911")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == BARCODE_METHOD_NAMES[2]
+    assert params["barcode"] == "0049000028911"
+    for opt in (
+        "include_sub_categories",
+        "include_food_images",
+        "include_food_attributes",
+        "flag_default_serving",
+        "region",
+        "language",
+    ):
+        assert opt not in params
+    assert result == food_obj
+
+
+@pytest.mark.parametrize(
+    "kwarg,value",
+    [
+        ("include_sub_categories", True),
+        ("include_food_images", True),
+        ("include_food_attributes", True),
+        ("flag_default_serving", True),
+        ("region", "US"),
+        ("language", "en"),
+    ],
+)
+def test_food_find_id_for_barcode_v2_optional_forwarding(fs, kwarg, value):
+    payload = {"food": {}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_find_id_for_barcode_v2("0049000028911", **{kwarg: value})
+    assert mock_call.call_args.args[0][kwarg] == value
+
+
+def test_food_find_id_for_barcode_v2_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.food_find_id_for_barcode_v2("0049000028911") is None
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_food_find_id_for_barcode_premier_propagates(fs, version):
+    with patch.object(
+        Fatsecret,
+        "_call",
+        side_effect=PremierRequiredError(207, "Premier (barcode) required"),
+    ):
+        with pytest.raises(PremierRequiredError):
+            getattr(fs, f"food_find_id_for_barcode_v{version}")("0049000028911")

--- a/tests/unit/endpoints/test_meals.py
+++ b/tests/unit/endpoints/test_meals.py
@@ -1,0 +1,417 @@
+"""Exhaustive unit tests for the Saved Meals resource.
+
+Covers the ten method-version pairs (all Premier-only):
+  * saved_meal.create        v1
+  * saved_meal.edit          v1
+  * saved_meal.delete        v1
+  * saved_meals.get          v1, v2
+  * saved_meal_item.add      v1
+  * saved_meal_item.edit     v1
+  * saved_meal_item.delete   v1
+  * saved_meal_items.get     v1, v2
+
+For each method-version we assert:
+  1. Happy path: correct ``method=`` value and HTTP verb to ``_call``.
+  2. Required params propagated.
+  3. Optional params: present when supplied, absent when None.
+  4. Mutators returning ``{"success": 1}`` collapsed to ``True``.
+  5. ``saved_meal.create`` / ``saved_meal_item.add`` IDs unwrapped.
+  6. Get-list endpoints: single-dict coerced, list passed through, empty → [].
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+# ---------------------------------------------------------------------------
+# saved_meal.create v1
+# ---------------------------------------------------------------------------
+
+
+def test_saved_meal_create_v1_happy_path(fs):
+    payload = {"saved_meal_id": {"value": "12345"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.saved_meal_create_v1("My Lunch")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "saved_meal.create"
+    assert params["saved_meal_name"] == "My Lunch"
+    # Optionals omitted when None.
+    assert "saved_meal_description" not in params
+    assert "meals" not in params
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    assert result == {"value": "12345"}
+
+
+def test_saved_meal_create_v1_with_all_optionals(fs):
+    payload = {"saved_meal_id": "999"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.saved_meal_create_v1(
+            "Dinner",
+            saved_meal_description="A tasty dinner",
+            meals="breakfast,lunch",
+        )
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "saved_meal.create"
+    assert params["saved_meal_name"] == "Dinner"
+    assert params["saved_meal_description"] == "A tasty dinner"
+    # `meals` is documented as a string in v1 — pass-through, no list-join.
+    assert params["meals"] == "breakfast,lunch"
+    assert result == "999"
+
+
+def test_saved_meal_create_v1_meals_is_passthrough_string(fs):
+    """v1 wrapper does NOT mutate `meals`; the legacy alias joined lists."""
+    payload = {"saved_meal_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.saved_meal_create_v1("name", meals="breakfast")
+
+    params = mock_call.call_args.args[0]
+    assert params["meals"] == "breakfast"
+    assert isinstance(params["meals"], str)
+
+
+def test_saved_meal_create_v1_empty_response(fs):
+    # `_unwrap` for a scalar key returns None when the key is missing.
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = fs.saved_meal_create_v1("name")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# saved_meal.edit v1
+# ---------------------------------------------------------------------------
+
+
+def test_saved_meal_edit_v1_happy_path(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"success": 1}
+    ) as mock_call:
+        result = fs.saved_meal_edit_v1("123")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "saved_meal.edit"
+    assert params["saved_meal_id"] == "123"
+    assert "saved_meal_name" not in params
+    assert "saved_meal_description" not in params
+    assert "meals" not in params
+    assert mock_call.call_args.kwargs.get("method") == "PUT"
+    assert result is True
+
+
+def test_saved_meal_edit_v1_with_all_optionals(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"success": 1}
+    ) as mock_call:
+        result = fs.saved_meal_edit_v1(
+            "123",
+            saved_meal_name="Renamed",
+            saved_meal_description="updated desc",
+            meals="dinner",
+        )
+
+    params = mock_call.call_args.args[0]
+    assert params["saved_meal_name"] == "Renamed"
+    assert params["saved_meal_description"] == "updated desc"
+    assert params["meals"] == "dinner"
+    assert result is True
+
+
+def test_saved_meal_edit_v1_success_string_one_also_true(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": "1"}):
+        result = fs.saved_meal_edit_v1("123")
+    assert result is True
+
+
+def test_saved_meal_edit_v1_non_success_payload_passthrough(fs):
+    payload = {"error": "something"}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.saved_meal_edit_v1("123")
+    assert result == payload
+
+
+# ---------------------------------------------------------------------------
+# saved_meal.delete v1
+# ---------------------------------------------------------------------------
+
+
+def test_saved_meal_delete_v1_happy_path(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"success": 1}
+    ) as mock_call:
+        result = fs.saved_meal_delete_v1("123")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "saved_meal.delete"
+    assert params["saved_meal_id"] == "123"
+    assert mock_call.call_args.kwargs.get("method") == "DELETE"
+    assert result is True
+
+
+def test_saved_meal_delete_v1_failure_passthrough(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 0}):
+        result = fs.saved_meal_delete_v1("123")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# saved_meals.get  (v1, v2)
+# ---------------------------------------------------------------------------
+
+SAVED_MEALS_GET_VERSIONS = [
+    ("saved_meals_get_v1", "saved_meals.get"),
+    ("saved_meals_get_v2", "saved_meals.get.v2"),
+]
+
+
+@pytest.mark.parametrize("method_name,api_method", SAVED_MEALS_GET_VERSIONS)
+def test_saved_meals_get_happy_path(fs, method_name, api_method):
+    payload = {
+        "saved_meals": {
+            "saved_meal": [
+                {"saved_meal_id": "1", "saved_meal_name": "Lunch"},
+                {"saved_meal_id": "2", "saved_meal_name": "Dinner"},
+            ]
+        }
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)()
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert "meal" not in params
+    # HTTP verb defaults to GET (no `method=` kwarg passed).
+    assert mock_call.call_args.kwargs.get("method") in (None, "GET")
+    assert result == [
+        {"saved_meal_id": "1", "saved_meal_name": "Lunch"},
+        {"saved_meal_id": "2", "saved_meal_name": "Dinner"},
+    ]
+
+
+@pytest.mark.parametrize("method_name,api_method", SAVED_MEALS_GET_VERSIONS)
+def test_saved_meals_get_with_meal_filter(fs, method_name, api_method):
+    payload = {"saved_meals": {"saved_meal": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)(meal="breakfast")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert params["meal"] == "breakfast"
+    assert result == []
+
+
+@pytest.mark.parametrize("method_name,_", SAVED_MEALS_GET_VERSIONS)
+def test_saved_meals_get_single_dict_coerced(fs, method_name, _):
+    payload = {"saved_meals": {"saved_meal": {"saved_meal_id": "1"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == [{"saved_meal_id": "1"}]
+
+
+@pytest.mark.parametrize("method_name,_", SAVED_MEALS_GET_VERSIONS)
+def test_saved_meals_get_empty_response(fs, method_name, _):
+    # No `saved_meals` key at all → unwrap returns [].
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = getattr(fs, method_name)()
+    assert result == []
+
+
+@pytest.mark.parametrize("method_name,_", SAVED_MEALS_GET_VERSIONS)
+def test_saved_meals_get_null_inner_response(fs, method_name, _):
+    with patch.object(
+        Fatsecret, "_call", return_value={"saved_meals": None}
+    ):
+        result = getattr(fs, method_name)()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# saved_meal_item.add v1
+# ---------------------------------------------------------------------------
+
+
+def test_saved_meal_item_add_v1_happy_path(fs):
+    payload = {"saved_meal_item_id": "77"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.saved_meal_item_add_v1(
+            saved_meal_id="10",
+            food_id="200",
+            saved_meal_item_name="Apple",
+            serving_id="3",
+            number_of_units=1.5,
+        )
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "saved_meal_item.add"
+    assert params["saved_meal_id"] == "10"
+    assert params["food_id"] == "200"
+    assert params["saved_meal_item_name"] == "Apple"
+    assert params["serving_id"] == "3"
+    assert params["number_of_units"] == 1.5
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    assert result == "77"
+
+
+def test_saved_meal_item_add_v1_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = fs.saved_meal_item_add_v1("1", "2", "n", "3", 1.0)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# saved_meal_item.edit v1
+# ---------------------------------------------------------------------------
+
+
+def test_saved_meal_item_edit_v1_happy_path(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"success": 1}
+    ) as mock_call:
+        result = fs.saved_meal_item_edit_v1("77")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "saved_meal_item.edit"
+    assert params["saved_meal_item_id"] == "77"
+    assert "saved_meal_item_name" not in params
+    assert "number_of_units" not in params
+    assert mock_call.call_args.kwargs.get("method") == "PUT"
+    assert result is True
+
+
+def test_saved_meal_item_edit_v1_with_all_optionals(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"success": 1}
+    ) as mock_call:
+        result = fs.saved_meal_item_edit_v1(
+            "77",
+            saved_meal_item_name="Renamed Apple",
+            number_of_units=2.0,
+        )
+
+    params = mock_call.call_args.args[0]
+    assert params["saved_meal_item_name"] == "Renamed Apple"
+    assert params["number_of_units"] == 2.0
+    assert result is True
+
+
+def test_saved_meal_item_edit_v1_cannot_change_serving_id(fs):
+    """Per the YAML spec, ``serving_id`` is NOT an editable param.
+
+    The wrapper signature must not accept it as a keyword argument.
+    """
+    import inspect
+
+    sig = inspect.signature(Fatsecret.saved_meal_item_edit_v1)
+    assert "serving_id" not in sig.parameters
+    # Documented editable params are present:
+    assert "saved_meal_item_id" in sig.parameters
+    assert "saved_meal_item_name" in sig.parameters
+    assert "number_of_units" in sig.parameters
+
+
+def test_saved_meal_item_edit_v1_partial_optional_only_name(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"success": 1}
+    ) as mock_call:
+        fs.saved_meal_item_edit_v1("77", saved_meal_item_name="x")
+
+    params = mock_call.call_args.args[0]
+    assert params["saved_meal_item_name"] == "x"
+    assert "number_of_units" not in params
+
+
+# ---------------------------------------------------------------------------
+# saved_meal_item.delete v1
+# ---------------------------------------------------------------------------
+
+
+def test_saved_meal_item_delete_v1_happy_path(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"success": 1}
+    ) as mock_call:
+        result = fs.saved_meal_item_delete_v1("77")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "saved_meal_item.delete"
+    assert params["saved_meal_item_id"] == "77"
+    assert mock_call.call_args.kwargs.get("method") == "DELETE"
+    assert result is True
+
+
+def test_saved_meal_item_delete_v1_failure_passthrough(fs):
+    payload = {"success": 0}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.saved_meal_item_delete_v1("77")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# saved_meal_items.get  (v1, v2)
+# ---------------------------------------------------------------------------
+
+SAVED_MEAL_ITEMS_GET_VERSIONS = [
+    ("saved_meal_items_get_v1", "saved_meal_items.get"),
+    ("saved_meal_items_get_v2", "saved_meal_items.get.v2"),
+]
+
+
+@pytest.mark.parametrize(
+    "method_name,api_method", SAVED_MEAL_ITEMS_GET_VERSIONS
+)
+def test_saved_meal_items_get_happy_path(fs, method_name, api_method):
+    payload = {
+        "saved_meal_items": {
+            "saved_meal_item": [
+                {"saved_meal_item_id": "1"},
+                {"saved_meal_item_id": "2"},
+            ]
+        }
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)("10")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert params["saved_meal_id"] == "10"
+    assert mock_call.call_args.kwargs.get("method") in (None, "GET")
+    assert result == [
+        {"saved_meal_item_id": "1"},
+        {"saved_meal_item_id": "2"},
+    ]
+
+
+@pytest.mark.parametrize("method_name,_", SAVED_MEAL_ITEMS_GET_VERSIONS)
+def test_saved_meal_items_get_single_dict_coerced(fs, method_name, _):
+    payload = {
+        "saved_meal_items": {"saved_meal_item": {"saved_meal_item_id": "1"}}
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)("10")
+    assert result == [{"saved_meal_item_id": "1"}]
+
+
+@pytest.mark.parametrize("method_name,_", SAVED_MEAL_ITEMS_GET_VERSIONS)
+def test_saved_meal_items_get_empty_response(fs, method_name, _):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = getattr(fs, method_name)("10")
+    assert result == []
+
+
+@pytest.mark.parametrize("method_name,_", SAVED_MEAL_ITEMS_GET_VERSIONS)
+def test_saved_meal_items_get_null_inner_response(fs, method_name, _):
+    with patch.object(
+        Fatsecret, "_call", return_value={"saved_meal_items": None}
+    ):
+        result = getattr(fs, method_name)("10")
+    assert result == []

--- a/tests/unit/endpoints/test_native.py
+++ b/tests/unit/endpoints/test_native.py
@@ -1,0 +1,576 @@
+"""Exhaustive unit tests for the Native APIs + Feedback resources.
+
+Covers four method-version pairs, all Premier-exclusive REST-URL POST endpoints:
+
+  * natural.language.processing  v1  -> ``natural_language_processing_v1``
+  * image.recognition            v1  -> ``image_recognition_v1``
+  * image.recognition            v2  -> ``image_recognition_v2``
+  * feedback                     v1  -> ``feedback_v1``
+
+These differ from the rest of the SDK in three important ways, all of which
+this file exercises:
+
+  1. They use a REST URL path (passed as ``url=``) instead of the legacy
+     ``?method=`` query parameter.  Tests assert that NO ``method=`` key
+     appears in the ``params`` dict sent to ``_call``.
+  2. They are HTTP POST.  Tests assert ``method="POST"`` (the HTTP-verb
+     keyword on ``_call``).
+  3. The payload is sent as a JSON body via ``json_body=``, not as form/query
+     params.  Tests assert ``json_body`` contains required parameters and
+     optionals only when supplied.
+
+Per method-version we assert:
+  * Happy path: correct URL, HTTP verb, ``json_body`` shape, ``params`` is
+    just ``{"format": "json"}`` with no API ``method`` key.
+  * Every optional parameter, both individually and en masse:
+    present-when-set, absent-when-``None``.
+  * Return-shape: ``food_response`` is unwrapped to a list (NLP /
+    image-recognition); feedback returns the raw payload dict containing
+    the three signed PUT URLs + ``contentTypeHeader``.
+  * ``PremierRequiredError`` propagation (all four methods are Premier).
+  * ``ScopeRequiredError`` propagation (per-method OAuth2 scope check).
+
+image_recognition specifics:
+  * ``image_b64`` is passed through verbatim - the wrapper does NOT
+    re-encode.  The 999,982-char upper bound is upstream's problem.
+  * v2 accepts WebP (per the YAML).  The wrapper takes no format hint, so
+    we just verify the same call shape works for a WebP-like payload.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret, PremierRequiredError, ScopeRequiredError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / constants
+# ---------------------------------------------------------------------------
+
+NLP_URL = "https://platform.fatsecret.com/rest/natural-language-processing/v1"
+IMG_V1_URL = "https://platform.fatsecret.com/rest/image-recognition/v1"
+IMG_V2_URL = "https://platform.fatsecret.com/rest/image-recognition/v2"
+FEEDBACK_URL = "https://platform.fatsecret.com/rest/feedback/v1"
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+def _assert_url_post_call(mock_call, expected_url):
+    """Common assertion: REST URL POST endpoint with no ``method=`` API param."""
+    kwargs = mock_call.call_args.kwargs
+    assert kwargs["url"] == expected_url
+    assert kwargs["method"] == "POST"
+    # params is the query-string dict; for URL endpoints it carries only format.
+    assert kwargs["params"] == {"format": "json"}
+    assert "method" not in kwargs["params"]
+    return kwargs
+
+
+# ===========================================================================
+# natural.language.processing v1
+# ===========================================================================
+
+
+def test_nlp_v1_happy_path_minimal(fs):
+    payload = {"food_response": [{"food_id": "1", "food_entry_name": "apple"}]}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.natural_language_processing_v1("I ate an apple")
+
+    kwargs = _assert_url_post_call(mock_call, NLP_URL)
+    body = kwargs["json_body"]
+    assert body == {"user_input": "I ate an apple"}
+    # No optionals leaked.
+    for opt in ("include_food_data", "eaten_foods", "region", "language"):
+        assert opt not in body
+    assert result == [{"food_id": "1", "food_entry_name": "apple"}]
+
+
+def test_nlp_v1_all_optionals_present_when_supplied(fs):
+    payload = {"food_response": []}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.natural_language_processing_v1(
+            "two eggs and toast",
+            include_food_data=True,
+            eaten_foods=[{"food_id": "42"}],
+            region="US",
+            language="en",
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body["user_input"] == "two eggs and toast"
+    assert body["include_food_data"] is True
+    assert body["eaten_foods"] == [{"food_id": "42"}]
+    assert body["region"] == "US"
+    assert body["language"] == "en"
+
+
+@pytest.mark.parametrize(
+    "kwarg,value",
+    [
+        ("include_food_data", True),
+        ("include_food_data", False),
+        ("eaten_foods", [{"food_id": "1"}]),
+        ("region", "GB"),
+        ("language", "fr"),
+    ],
+)
+def test_nlp_v1_each_optional_individually(fs, kwarg, value):
+    payload = {"food_response": []}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.natural_language_processing_v1("hello", **{kwarg: value})
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body[kwarg] == value
+    others = {"include_food_data", "eaten_foods", "region", "language"} - {kwarg}
+    for o in others:
+        assert o not in body
+
+
+def test_nlp_v1_omits_optionals_when_none(fs):
+    payload = {"food_response": []}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.natural_language_processing_v1(
+            "x",
+            include_food_data=None,
+            eaten_foods=None,
+            region=None,
+            language=None,
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body == {"user_input": "x"}
+
+
+def test_nlp_v1_response_with_list_passthrough(fs):
+    payload = {
+        "food_response": [
+            {"food_id": "1", "food_entry_name": "apple"},
+            {"food_id": "2", "food_entry_name": "egg"},
+        ]
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.natural_language_processing_v1("apple and egg")
+    assert result == [
+        {"food_id": "1", "food_entry_name": "apple"},
+        {"food_id": "2", "food_entry_name": "egg"},
+    ]
+
+
+def test_nlp_v1_response_with_empty_list_returns_empty(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"food_response": []}
+    ):
+        result = fs.natural_language_processing_v1("nothing")
+    assert result == []
+
+
+def test_nlp_v1_response_without_food_response_passes_through(fs):
+    # The wrapper only unwraps when the key is present; otherwise it returns
+    # the raw payload (defensive against future schema changes).
+    raw = {"something_else": "value"}
+    with patch.object(Fatsecret, "_call", return_value=raw):
+        result = fs.natural_language_processing_v1("x")
+    assert result == raw
+
+
+def test_nlp_v1_propagates_premier_required(fs):
+    with patch.object(
+        Fatsecret, "_call",
+        side_effect=PremierRequiredError(207, "Premier required"),
+    ):
+        with pytest.raises(PremierRequiredError):
+            fs.natural_language_processing_v1("x")
+
+
+def test_nlp_v1_propagates_scope_required(fs):
+    with patch.object(
+        Fatsecret, "_call",
+        side_effect=ScopeRequiredError(208, "nlp scope required"),
+    ):
+        with pytest.raises(ScopeRequiredError):
+            fs.natural_language_processing_v1("x")
+
+
+# ===========================================================================
+# image.recognition v1 + v2 (parameterised - same signature, different URL)
+# ===========================================================================
+
+IMG_VERSIONS = [
+    ("image_recognition_v1", IMG_V1_URL),
+    ("image_recognition_v2", IMG_V2_URL),
+]
+
+
+@pytest.mark.parametrize("method_name,expected_url", IMG_VERSIONS)
+def test_image_recognition_happy_path_minimal(fs, method_name, expected_url):
+    payload = {"food_response": [{"food_id": "9", "food_entry_name": "pizza"}]}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)("BASE64IMG")
+
+    kwargs = _assert_url_post_call(mock_call, expected_url)
+    body = kwargs["json_body"]
+    assert body == {"image_b64": "BASE64IMG"}
+    for opt in ("include_food_data", "eaten_foods", "region", "language"):
+        assert opt not in body
+    assert result == [{"food_id": "9", "food_entry_name": "pizza"}]
+
+
+@pytest.mark.parametrize("method_name,expected_url", IMG_VERSIONS)
+def test_image_recognition_image_b64_is_passed_through_verbatim(
+    fs, method_name, expected_url
+):
+    # The wrapper must NOT re-encode an already-base64 string.  A real-world
+    # caller may pass a Standard or URL-safe Base64 string with/without
+    # padding; both go straight to the wire.
+    samples = [
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+        "QUJDREVGRw==",  # "ABCDEFG"
+        "A" * 1024,  # not really base64 but the wrapper must not validate
+    ]
+    for raw in samples:
+        with patch.object(Fatsecret, "_call", return_value={"food_response": []}) as mc:
+            getattr(fs, method_name)(raw)
+        assert mc.call_args.kwargs["json_body"]["image_b64"] == raw
+
+
+def test_image_recognition_v2_accepts_webp_style_payload(fs):
+    # v2 advertises WebP support; the wrapper itself takes no format hint, so
+    # we just confirm a typical WebP-base64 prefix flows through unaltered.
+    webp_b64 = "UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAQAcJaQAA3AA/v3AgAA="
+    with patch.object(
+        Fatsecret, "_call", return_value={"food_response": []}
+    ) as mc:
+        fs.image_recognition_v2(webp_b64)
+    assert mc.call_args.kwargs["json_body"]["image_b64"] == webp_b64
+
+
+@pytest.mark.parametrize("method_name,_url", IMG_VERSIONS)
+def test_image_recognition_all_optionals_present_when_supplied(
+    fs, method_name, _url
+):
+    payload = {"food_response": []}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(
+            "IMGB64",
+            include_food_data=True,
+            eaten_foods=[{"food_id": "1"}, {"food_id": "2"}],
+            region="US",
+            language="en",
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body["image_b64"] == "IMGB64"
+    assert body["include_food_data"] is True
+    assert body["eaten_foods"] == [{"food_id": "1"}, {"food_id": "2"}]
+    assert body["region"] == "US"
+    assert body["language"] == "en"
+
+
+@pytest.mark.parametrize("method_name,_url", IMG_VERSIONS)
+@pytest.mark.parametrize(
+    "kwarg,value",
+    [
+        ("include_food_data", True),
+        ("include_food_data", False),
+        ("eaten_foods", [{"food_id": "1"}]),
+        ("region", "AU"),
+        ("language", "de"),
+    ],
+)
+def test_image_recognition_each_optional_individually(
+    fs, method_name, _url, kwarg, value
+):
+    payload = {"food_response": []}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)("IMG", **{kwarg: value})
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body[kwarg] == value
+    others = {"include_food_data", "eaten_foods", "region", "language"} - {kwarg}
+    for o in others:
+        assert o not in body
+
+
+@pytest.mark.parametrize("method_name,_url", IMG_VERSIONS)
+def test_image_recognition_omits_optionals_when_none(fs, method_name, _url):
+    payload = {"food_response": []}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(
+            "IMG",
+            include_food_data=None,
+            eaten_foods=None,
+            region=None,
+            language=None,
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body == {"image_b64": "IMG"}
+
+
+@pytest.mark.parametrize("method_name,_url", IMG_VERSIONS)
+def test_image_recognition_response_list_passthrough(fs, method_name, _url):
+    payload = {
+        "food_response": [
+            {"food_id": "a"},
+            {"food_id": "b"},
+        ]
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)("IMG")
+    assert result == [{"food_id": "a"}, {"food_id": "b"}]
+
+
+@pytest.mark.parametrize("method_name,_url", IMG_VERSIONS)
+def test_image_recognition_empty_food_response_returns_empty(
+    fs, method_name, _url
+):
+    with patch.object(
+        Fatsecret, "_call", return_value={"food_response": []}
+    ):
+        result = getattr(fs, method_name)("IMG")
+    assert result == []
+
+
+@pytest.mark.parametrize("method_name,_url", IMG_VERSIONS)
+def test_image_recognition_response_without_food_response_passes_through(
+    fs, method_name, _url
+):
+    raw = {"unknown_top_level": [1, 2, 3]}
+    with patch.object(Fatsecret, "_call", return_value=raw):
+        result = getattr(fs, method_name)("IMG")
+    assert result == raw
+
+
+@pytest.mark.parametrize("method_name,_url", IMG_VERSIONS)
+def test_image_recognition_propagates_premier_required(fs, method_name, _url):
+    with patch.object(
+        Fatsecret, "_call",
+        side_effect=PremierRequiredError(207, "Premier required"),
+    ):
+        with pytest.raises(PremierRequiredError):
+            getattr(fs, method_name)("IMG")
+
+
+@pytest.mark.parametrize("method_name,_url", IMG_VERSIONS)
+def test_image_recognition_propagates_scope_required(fs, method_name, _url):
+    with patch.object(
+        Fatsecret, "_call",
+        side_effect=ScopeRequiredError(208, "image-recognition scope required"),
+    ):
+        with pytest.raises(ScopeRequiredError):
+            getattr(fs, method_name)("IMG")
+
+
+# ===========================================================================
+# feedback v1
+# ===========================================================================
+
+
+# Realistic-looking signed PUT response per the YAML.  The wrapper returns
+# this dict verbatim; the caller is responsible for PUTting bytes to each URL.
+FEEDBACK_PUT_RESPONSE = {
+    "barcode": "https://signed.example/barcode?sig=AAA",
+    "packaging": "https://signed.example/packaging?sig=BBB",
+    "nutrition": "https://signed.example/nutrition?sig=CCC",
+    "contentTypeHeader": "image/jpeg",
+}
+
+
+def test_feedback_v1_happy_path_minimal(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        result = fs.feedback_v1(issue_type_id=1, external_id="ext-42")
+
+    kwargs = _assert_url_post_call(mock_call, FEEDBACK_URL)
+    body = kwargs["json_body"]
+    assert body == {"issue_type_id": 1, "external_id": "ext-42"}
+    # None of the optionals leaked.
+    for opt in (
+        "barcode",
+        "issue_type",
+        "notes",
+        "returned_food",
+        "image_file_extension",
+        "region",
+        "language",
+    ):
+        assert opt not in body
+
+    # Wrapper returns the raw payload (three signed PUT URLs + header).
+    assert result == FEEDBACK_PUT_RESPONSE
+    assert result["barcode"].startswith("https://")
+    assert result["packaging"].startswith("https://")
+    assert result["nutrition"].startswith("https://")
+    assert result["contentTypeHeader"] == "image/jpeg"
+
+
+def test_feedback_v1_all_simple_optionals_present(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        fs.feedback_v1(
+            issue_type_id=2,
+            external_id="ext-1",
+            barcode=12345678,
+            issue_type="Wrong Nutrition",
+            notes="protein looks off",
+            image_file_extension="jpg",
+            region="US",
+            language="en",
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body["issue_type_id"] == 2
+    assert body["external_id"] == "ext-1"
+    assert body["barcode"] == 12345678
+    assert body["issue_type"] == "Wrong Nutrition"
+    assert body["notes"] == "protein looks off"
+    assert body["image_file_extension"] == "jpg"
+    assert body["region"] == "US"
+    assert body["language"] == "en"
+    # ``returned_food`` is built only when food/serving ids are passed.
+    assert "returned_food" not in body
+
+
+@pytest.mark.parametrize(
+    "kwarg,value",
+    [
+        ("barcode", 99999999),
+        ("issue_type", "Other"),
+        ("notes", "n/a"),
+        ("image_file_extension", "png"),
+        ("region", "GB"),
+        ("language", "fr"),
+    ],
+)
+def test_feedback_v1_each_simple_optional_individually(fs, kwarg, value):
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        fs.feedback_v1(issue_type_id=99, external_id="e", **{kwarg: value})
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body[kwarg] == value
+    others = {
+        "barcode",
+        "issue_type",
+        "notes",
+        "image_file_extension",
+        "region",
+        "language",
+    } - {kwarg}
+    for o in others:
+        assert o not in body
+    assert "returned_food" not in body
+
+
+def test_feedback_v1_omits_simple_optionals_when_none(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        fs.feedback_v1(
+            issue_type_id=1,
+            external_id="e",
+            barcode=None,
+            issue_type=None,
+            notes=None,
+            returned_food_id=None,
+            returned_serving_id=None,
+            image_file_extension=None,
+            region=None,
+            language=None,
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body == {"issue_type_id": 1, "external_id": "e"}
+
+
+def test_feedback_v1_returned_food_built_from_food_id_only(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        fs.feedback_v1(
+            issue_type_id=2,
+            external_id="e",
+            returned_food_id=555,
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body["returned_food"] == {"food_id": 555}
+
+
+def test_feedback_v1_returned_food_built_from_serving_id_only(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        fs.feedback_v1(
+            issue_type_id=2,
+            external_id="e",
+            returned_serving_id=777,
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body["returned_food"] == {"serving_id": 777}
+
+
+def test_feedback_v1_returned_food_built_from_both_ids(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        fs.feedback_v1(
+            issue_type_id=2,
+            external_id="e",
+            returned_food_id=555,
+            returned_serving_id=777,
+        )
+    body = mock_call.call_args.kwargs["json_body"]
+    assert body["returned_food"] == {"food_id": 555, "serving_id": 777}
+
+
+def test_feedback_v1_returned_food_absent_when_both_none(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        fs.feedback_v1(issue_type_id=1, external_id="e")
+    assert "returned_food" not in mock_call.call_args.kwargs["json_body"]
+
+
+@pytest.mark.parametrize("issue_type_id", [1, 2, 3, 4, 99])
+def test_feedback_v1_accepts_documented_issue_type_ids(fs, issue_type_id):
+    # Per the docstring: 1=Wrong Name/Brand, 2=Wrong Nutrition,
+    # 3=Missing Serving Size, 4=Barcode not found, 99=Other.  The wrapper
+    # passes the int through without validation.
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ) as mock_call:
+        fs.feedback_v1(issue_type_id=issue_type_id, external_id="e")
+    assert mock_call.call_args.kwargs["json_body"]["issue_type_id"] == issue_type_id
+
+
+def test_feedback_v1_returns_raw_payload_shape(fs):
+    # The wrapper does NOT unwrap feedback responses - it returns the raw
+    # dict containing the three signed PUT URLs + contentTypeHeader.
+    with patch.object(
+        Fatsecret, "_call", return_value=FEEDBACK_PUT_RESPONSE
+    ):
+        result = fs.feedback_v1(issue_type_id=1, external_id="e")
+    assert set(result.keys()) == {
+        "barcode",
+        "packaging",
+        "nutrition",
+        "contentTypeHeader",
+    }
+
+
+def test_feedback_v1_propagates_premier_required(fs):
+    with patch.object(
+        Fatsecret, "_call",
+        side_effect=PremierRequiredError(207, "Premier required"),
+    ):
+        with pytest.raises(PremierRequiredError):
+            fs.feedback_v1(issue_type_id=1, external_id="e")
+
+
+def test_feedback_v1_propagates_scope_required(fs):
+    with patch.object(
+        Fatsecret, "_call",
+        side_effect=ScopeRequiredError(208, "feedback scope required"),
+    ):
+        with pytest.raises(ScopeRequiredError):
+            fs.feedback_v1(issue_type_id=1, external_id="e")

--- a/tests/unit/endpoints/test_profile_foods.py
+++ b/tests/unit/endpoints/test_profile_foods.py
@@ -1,0 +1,543 @@
+"""Exhaustive unit tests for the Profile-Foods resource.
+
+Covers the ten method-version pairs:
+
+  * food.create                    v1, v2   (Premier-exclusive, POST)
+  * food.add_favorite              v1       (POST)
+  * food.delete_favorite           v1       (DELETE)
+  * foods.get_favorites            v1, v2   (GET, list)
+  * foods.get_most_eaten           v1, v2   (GET, list)
+  * foods.get_recently_eaten       v1, v2   (GET, list; v2 ambiguous Premier/Basic
+                                              upstream — wrapper behavior tested
+                                              as-is, ambiguity not resolved)
+
+For each method-version we assert:
+  1. Happy path: correct ``method=`` value, correct HTTP verb, required
+     params present, unwrapped return shape.
+  2. Optional params: present-when-set, absent-when-None.
+  3. List unwrap with single-vs-list coercion for list endpoints.
+  4. Empty / missing response coerced to ``[]`` (lists) or ``True`` (mutators).
+  5. ``food.create`` is Premier — ``PremierRequiredError`` from ``_call``
+     propagates to the caller.
+  6. ``food.create`` returns ``food_id`` (unwrap).
+  7. ``food.create v2`` schema deltas vs v1 (drops ``other_carbohydrate``;
+     adds ``added_sugars``, ``vitamin_d``).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret, PremierRequiredError
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+# ---------------------------------------------------------------------------
+# food.create  (v1, v2)  — Premier-exclusive, POST
+# ---------------------------------------------------------------------------
+
+CREATE_VERSIONS = [
+    ("food_create_v1", "food.create"),
+    ("food_create_v2", "food.create.v2"),
+]
+
+REQUIRED_CREATE_KWARGS = dict(
+    brand_name="Acme",
+    food_name="Bar",
+    serving_size="1 bar",
+    calories=200.0,
+    fat=10.0,
+    carbohydrate=20.0,
+    protein=5.0,
+)
+
+
+@pytest.mark.parametrize("method_name,api_method", CREATE_VERSIONS)
+def test_food_create_happy_path(fs, method_name, api_method):
+    payload = {"food_id": {"value": "12345"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)(**REQUIRED_CREATE_KWARGS)
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert params["brand_name"] == "Acme"
+    assert params["food_name"] == "Bar"
+    assert params["serving_size"] == "1 bar"
+    assert params["calories"] == 200.0
+    assert params["fat"] == 10.0
+    assert params["carbohydrate"] == 20.0
+    assert params["protein"] == 5.0
+    # HTTP verb is POST.
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    # Unwrap returns the food_id value.
+    assert result == {"value": "12345"}
+
+
+@pytest.mark.parametrize("method_name,_api", CREATE_VERSIONS)
+def test_food_create_unwraps_food_id_scalar(fs, method_name, _api):
+    payload = {"food_id": "9876"}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)(**REQUIRED_CREATE_KWARGS)
+    assert result == "9876"
+
+
+@pytest.mark.parametrize("method_name,_api", CREATE_VERSIONS)
+def test_food_create_omits_all_optionals_by_default(fs, method_name, _api):
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(**REQUIRED_CREATE_KWARGS)
+    params = mock_call.call_args.args[0]
+    # Shared optional fields must NOT appear in params when not supplied.
+    for key in (
+        "brand_type",
+        "serving_amount",
+        "serving_amount_unit",
+        "calories_from_fat",
+        "saturated_fat",
+        "polyunsaturated_fat",
+        "monounsaturated_fat",
+        "trans_fat",
+        "cholesterol",
+        "sodium",
+        "potassium",
+        "fiber",
+        "sugar",
+        "vitamin_a",
+        "vitamin_c",
+        "calcium",
+        "iron",
+        "region",
+        "language",
+    ):
+        assert key not in params
+
+
+# --- Shared optionals (present in BOTH v1 and v2) ----------------------------
+SHARED_OPTIONALS = [
+    ("brand_type", "manufacturer"),
+    ("serving_amount", "1.0"),
+    ("serving_amount_unit", "bar"),
+    ("calories_from_fat", 90.0),
+    ("saturated_fat", 3.0),
+    ("polyunsaturated_fat", 1.0),
+    ("monounsaturated_fat", 2.0),
+    ("trans_fat", 0.0),
+    ("cholesterol", 5.0),
+    ("sodium", 100.0),
+    ("potassium", 150.0),
+    ("fiber", 3.0),
+    ("sugar", 8.0),
+    ("vitamin_a", 10.0),
+    ("vitamin_c", 5.0),
+    ("calcium", 4.0),
+    ("iron", 2.0),
+    ("region", "US"),
+    ("language", "en"),
+]
+
+
+@pytest.mark.parametrize("method_name,_api", CREATE_VERSIONS)
+@pytest.mark.parametrize("kwarg,value", SHARED_OPTIONALS)
+def test_food_create_each_shared_optional_present_when_supplied(
+    fs, method_name, _api, kwarg, value
+):
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(**REQUIRED_CREATE_KWARGS, **{kwarg: value})
+    params = mock_call.call_args.args[0]
+    assert params[kwarg] == value
+
+
+@pytest.mark.parametrize("method_name,_api", CREATE_VERSIONS)
+@pytest.mark.parametrize("kwarg,_value", SHARED_OPTIONALS)
+def test_food_create_each_shared_optional_absent_when_none(
+    fs, method_name, _api, kwarg, _value
+):
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(**REQUIRED_CREATE_KWARGS, **{kwarg: None})
+    params = mock_call.call_args.args[0]
+    assert kwarg not in params
+
+
+# --- v1-only optional (other_carbohydrate) -----------------------------------
+
+
+def test_food_create_v1_accepts_other_carbohydrate(fs):
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_create_v1(other_carbohydrate=7.5, **REQUIRED_CREATE_KWARGS)
+    params = mock_call.call_args.args[0]
+    assert params["other_carbohydrate"] == 7.5
+    # v2-only fields must not appear in a v1 call.
+    assert "added_sugars" not in params
+    assert "vitamin_d" not in params
+
+
+def test_food_create_v1_omits_other_carbohydrate_when_none(fs):
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_create_v1(other_carbohydrate=None, **REQUIRED_CREATE_KWARGS)
+    params = mock_call.call_args.args[0]
+    assert "other_carbohydrate" not in params
+
+
+def test_food_create_v2_does_not_accept_other_carbohydrate(fs):
+    """v2 drops ``other_carbohydrate`` from the signature entirely."""
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        with pytest.raises(TypeError):
+            fs.food_create_v2(other_carbohydrate=7.5, **REQUIRED_CREATE_KWARGS)
+
+
+# --- v2-only optionals (added_sugars, vitamin_d) -----------------------------
+
+
+@pytest.mark.parametrize(
+    "kwarg,value", [("added_sugars", 4.0), ("vitamin_d", 2.5)]
+)
+def test_food_create_v2_accepts_v2_only_optionals(fs, kwarg, value):
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_create_v2(**REQUIRED_CREATE_KWARGS, **{kwarg: value})
+    params = mock_call.call_args.args[0]
+    assert params[kwarg] == value
+
+
+@pytest.mark.parametrize("kwarg", ["added_sugars", "vitamin_d"])
+def test_food_create_v2_omits_v2_only_optionals_when_none(fs, kwarg):
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_create_v2(**REQUIRED_CREATE_KWARGS, **{kwarg: None})
+    params = mock_call.call_args.args[0]
+    assert kwarg not in params
+
+
+@pytest.mark.parametrize("kwarg", ["added_sugars", "vitamin_d"])
+def test_food_create_v1_does_not_accept_v2_only_optionals(fs, kwarg):
+    """v1 signature predates ``added_sugars`` and ``vitamin_d``."""
+    payload = {"food_id": "1"}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        with pytest.raises(TypeError):
+            fs.food_create_v1(**REQUIRED_CREATE_KWARGS, **{kwarg: 1.0})
+
+
+# --- Premier propagation -----------------------------------------------------
+
+
+@pytest.mark.parametrize("method_name,_api", CREATE_VERSIONS)
+def test_food_create_propagates_premier_required_error(fs, method_name, _api):
+    with patch.object(
+        Fatsecret, "_call", side_effect=PremierRequiredError(21, "Premier required")
+    ):
+        with pytest.raises(PremierRequiredError):
+            getattr(fs, method_name)(**REQUIRED_CREATE_KWARGS)
+
+
+# ---------------------------------------------------------------------------
+# food.add_favorite  v1  (POST)
+# ---------------------------------------------------------------------------
+
+
+def test_food_add_favorite_v1_happy_path(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_add_favorite_v1("fid-1")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food.add_favorite"
+    assert params["food_id"] == "fid-1"
+    assert "serving_id" not in params
+    assert "number_of_units" not in params
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    assert result is True
+
+
+def test_food_add_favorite_v1_with_serving_id_only(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_add_favorite_v1("fid-1", serving_id="sid-9")
+    params = mock_call.call_args.args[0]
+    assert params["serving_id"] == "sid-9"
+    assert "number_of_units" not in params
+
+
+def test_food_add_favorite_v1_with_number_of_units_only(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_add_favorite_v1("fid-1", number_of_units=2.5)
+    params = mock_call.call_args.args[0]
+    assert params["number_of_units"] == 2.5
+    assert "serving_id" not in params
+
+
+def test_food_add_favorite_v1_with_both_optionals(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_add_favorite_v1("fid-1", serving_id="sid-9", number_of_units=2.5)
+    params = mock_call.call_args.args[0]
+    assert params["serving_id"] == "sid-9"
+    assert params["number_of_units"] == 2.5
+
+
+def test_food_add_favorite_v1_optionals_absent_when_none(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_add_favorite_v1("fid-1", serving_id=None, number_of_units=None)
+    params = mock_call.call_args.args[0]
+    assert "serving_id" not in params
+    assert "number_of_units" not in params
+
+
+def test_food_add_favorite_v1_success_string_one_returns_true(fs):
+    # `_mutator_success` accepts both int 1 and str "1".
+    with patch.object(Fatsecret, "_call", return_value={"success": "1"}):
+        result = fs.food_add_favorite_v1("fid-1")
+    assert result is True
+
+
+def test_food_add_favorite_v1_non_success_payload_passthrough(fs):
+    # Empty / non-success payloads pass through unchanged (no True coercion).
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = fs.food_add_favorite_v1("fid-1")
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# food.delete_favorite  v1  (DELETE)
+# ---------------------------------------------------------------------------
+
+
+def test_food_delete_favorite_v1_happy_path(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.food_delete_favorite_v1("fid-1")
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "food.delete_favorite"
+    assert params["food_id"] == "fid-1"
+    assert "serving_id" not in params
+    assert "number_of_units" not in params
+    assert mock_call.call_args.kwargs.get("method") == "DELETE"
+    assert result is True
+
+
+def test_food_delete_favorite_v1_with_serving_id_only(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_delete_favorite_v1("fid-1", serving_id="sid-9")
+    params = mock_call.call_args.args[0]
+    assert params["serving_id"] == "sid-9"
+    assert "number_of_units" not in params
+
+
+def test_food_delete_favorite_v1_with_number_of_units_only(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_delete_favorite_v1("fid-1", number_of_units=1.0)
+    params = mock_call.call_args.args[0]
+    assert params["number_of_units"] == 1.0
+    assert "serving_id" not in params
+
+
+def test_food_delete_favorite_v1_with_both_optionals(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_delete_favorite_v1(
+            "fid-1", serving_id="sid-9", number_of_units=1.0
+        )
+    params = mock_call.call_args.args[0]
+    assert params["serving_id"] == "sid-9"
+    assert params["number_of_units"] == 1.0
+
+
+def test_food_delete_favorite_v1_optionals_absent_when_none(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.food_delete_favorite_v1(
+            "fid-1", serving_id=None, number_of_units=None
+        )
+    params = mock_call.call_args.args[0]
+    assert "serving_id" not in params
+    assert "number_of_units" not in params
+
+
+def test_food_delete_favorite_v1_success_string_one_returns_true(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": "1"}):
+        result = fs.food_delete_favorite_v1("fid-1")
+    assert result is True
+
+
+def test_food_delete_favorite_v1_non_success_payload_passthrough(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = fs.food_delete_favorite_v1("fid-1")
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# foods.get_favorites  (v1, v2)  — GET, no params, list
+# ---------------------------------------------------------------------------
+
+FAVORITES_VERSIONS = [
+    ("foods_get_favorites_v1", "foods.get_favorites"),
+    ("foods_get_favorites_v2", "foods.get_favorites.v2"),
+]
+
+
+@pytest.mark.parametrize("method_name,api_method", FAVORITES_VERSIONS)
+def test_foods_get_favorites_happy_path(fs, method_name, api_method):
+    payload = {"foods": {"food": [{"food_id": "1"}, {"food_id": "2"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)()
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    # No HTTP verb override → defaults to GET.
+    assert mock_call.call_args.kwargs.get("method") is None
+    assert result == [{"food_id": "1"}, {"food_id": "2"}]
+
+
+@pytest.mark.parametrize("method_name,_api", FAVORITES_VERSIONS)
+def test_foods_get_favorites_single_dict_coerced_to_list(fs, method_name, _api):
+    payload = {"foods": {"food": {"food_id": "solo"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == [{"food_id": "solo"}]
+
+
+@pytest.mark.parametrize("method_name,_api", FAVORITES_VERSIONS)
+@pytest.mark.parametrize("payload", [{}, {"foods": None}])
+def test_foods_get_favorites_empty_response_returns_empty_list(
+    fs, method_name, _api, payload
+):
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# foods.get_most_eaten  (v1, v2)  — GET, optional meal, list
+# ---------------------------------------------------------------------------
+
+MOST_EATEN_VERSIONS = [
+    ("foods_get_most_eaten_v1", "foods.get_most_eaten"),
+    ("foods_get_most_eaten_v2", "foods.get_most_eaten.v2"),
+]
+
+
+@pytest.mark.parametrize("method_name,api_method", MOST_EATEN_VERSIONS)
+def test_foods_get_most_eaten_happy_path(fs, method_name, api_method):
+    payload = {"foods": {"food": [{"food_id": "1"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)()
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert "meal" not in params
+    assert mock_call.call_args.kwargs.get("method") is None
+    assert result == [{"food_id": "1"}]
+
+
+@pytest.mark.parametrize("method_name,_api", MOST_EATEN_VERSIONS)
+def test_foods_get_most_eaten_with_meal(fs, method_name, _api):
+    payload = {"foods": {"food": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(meal="breakfast")
+    params = mock_call.call_args.args[0]
+    assert params["meal"] == "breakfast"
+
+
+@pytest.mark.parametrize("method_name,_api", MOST_EATEN_VERSIONS)
+def test_foods_get_most_eaten_meal_absent_when_none(fs, method_name, _api):
+    payload = {"foods": {"food": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(meal=None)
+    params = mock_call.call_args.args[0]
+    assert "meal" not in params
+
+
+@pytest.mark.parametrize("method_name,_api", MOST_EATEN_VERSIONS)
+def test_foods_get_most_eaten_single_dict_coerced_to_list(fs, method_name, _api):
+    payload = {"foods": {"food": {"food_id": "solo"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == [{"food_id": "solo"}]
+
+
+@pytest.mark.parametrize("method_name,_api", MOST_EATEN_VERSIONS)
+@pytest.mark.parametrize("payload", [{}, {"foods": None}])
+def test_foods_get_most_eaten_empty_response_returns_empty_list(
+    fs, method_name, _api, payload
+):
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# foods.get_recently_eaten  (v1, v2)  — GET, optional meal, list
+# Note: v2 is flagged as ambiguous upstream (Premier vs Basic mismatch). We
+# only verify the wrapper's actual behavior — no Premier propagation test.
+# ---------------------------------------------------------------------------
+
+RECENTLY_EATEN_VERSIONS = [
+    ("foods_get_recently_eaten_v1", "foods.get_recently_eaten"),
+    ("foods_get_recently_eaten_v2", "foods.get_recently_eaten.v2"),
+]
+
+
+@pytest.mark.parametrize("method_name,api_method", RECENTLY_EATEN_VERSIONS)
+def test_foods_get_recently_eaten_happy_path(fs, method_name, api_method):
+    payload = {"foods": {"food": [{"food_id": "1"}, {"food_id": "2"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = getattr(fs, method_name)()
+
+    params = mock_call.call_args.args[0]
+    assert params["method"] == api_method
+    assert "meal" not in params
+    assert mock_call.call_args.kwargs.get("method") is None
+    assert result == [{"food_id": "1"}, {"food_id": "2"}]
+
+
+@pytest.mark.parametrize("method_name,_api", RECENTLY_EATEN_VERSIONS)
+def test_foods_get_recently_eaten_with_meal(fs, method_name, _api):
+    payload = {"foods": {"food": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(meal="dinner")
+    params = mock_call.call_args.args[0]
+    assert params["meal"] == "dinner"
+
+
+@pytest.mark.parametrize("method_name,_api", RECENTLY_EATEN_VERSIONS)
+def test_foods_get_recently_eaten_meal_absent_when_none(fs, method_name, _api):
+    payload = {"foods": {"food": []}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        getattr(fs, method_name)(meal=None)
+    params = mock_call.call_args.args[0]
+    assert "meal" not in params
+
+
+@pytest.mark.parametrize("method_name,_api", RECENTLY_EATEN_VERSIONS)
+def test_foods_get_recently_eaten_single_dict_coerced_to_list(
+    fs, method_name, _api
+):
+    payload = {"foods": {"food": {"food_id": "solo"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == [{"food_id": "solo"}]
+
+
+@pytest.mark.parametrize("method_name,_api", RECENTLY_EATEN_VERSIONS)
+@pytest.mark.parametrize("payload", [{}, {"foods": None}])
+def test_foods_get_recently_eaten_empty_response_returns_empty_list(
+    fs, method_name, _api, payload
+):
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = getattr(fs, method_name)()
+    assert result == []

--- a/tests/unit/endpoints/test_recipes.py
+++ b/tests/unit/endpoints/test_recipes.py
@@ -1,0 +1,530 @@
+"""Exhaustive unit tests for the versioned Recipes resource methods.
+
+Covers all 11 method-version pairs:
+
+  recipe.get             v1, v2
+  recipes.search         v1, v2, v3
+  recipe_types.get       v1, v2
+  recipe.add_favorite    v1
+  recipe.delete_favorite v1
+  recipes.get_favorites  v1, v2
+
+For each: happy-path call (method= + verb), every optional param present-when-set
+and absent-when-None, single-dict -> list normalization for list endpoints,
+empty-response defaults, version-exclusive params (v3 recipe_types, v2 grams_per_portion),
+favorite singular-name bug fix, and Premier propagation via kwargs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+# =========================================================================
+# recipe.get v1
+# =========================================================================
+
+
+def test_recipe_get_v1_happy_path(fs):
+    payload = {"recipe": {"recipe_id": "42", "recipe_name": "Pancakes"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipe_get_v1("42")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "recipe.get"
+    assert params["recipe_id"] == "42"
+    # No HTTP verb override (defaults to GET).
+    assert mock_call.call_args.kwargs == {}
+    assert result == {"recipe_id": "42", "recipe_name": "Pancakes"}
+
+
+def test_recipe_get_v1_optional_region_absent_when_none(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipe": {}}) as mock_call:
+        fs.recipe_get_v1("42")
+    params = mock_call.call_args.args[0]
+    assert "region" not in params
+
+
+def test_recipe_get_v1_optional_region_present_when_set(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipe": {}}) as mock_call:
+        fs.recipe_get_v1("42", region="US")
+    params = mock_call.call_args.args[0]
+    assert params["region"] == "US"
+
+
+def test_recipe_get_v1_does_not_send_grams_per_portion(fs):
+    """grams_per_portion is a v2-only response field, never sent on v1 calls."""
+    with patch.object(Fatsecret, "_call", return_value={"recipe": {}}) as mock_call:
+        fs.recipe_get_v1("42", region="US")
+    params = mock_call.call_args.args[0]
+    assert "grams_per_portion" not in params
+    assert params["method"] == "recipe.get"  # not .v2
+
+
+# =========================================================================
+# recipe.get v2
+# =========================================================================
+
+
+def test_recipe_get_v2_happy_path(fs):
+    payload = {
+        "recipe": {
+            "recipe_id": "42",
+            "recipe_name": "Pancakes",
+            "grams_per_portion": "120.0",
+        }
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipe_get_v2("42")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "recipe.get.v2"
+    assert params["recipe_id"] == "42"
+    assert result["grams_per_portion"] == "120.0"
+
+
+def test_recipe_get_v2_optional_region_absent_when_none(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipe": {}}) as mock_call:
+        fs.recipe_get_v2("42")
+    params = mock_call.call_args.args[0]
+    assert "region" not in params
+
+
+def test_recipe_get_v2_optional_region_present_when_set(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipe": {}}) as mock_call:
+        fs.recipe_get_v2("42", region="FR")
+    assert mock_call.call_args.args[0]["region"] == "FR"
+
+
+def test_recipe_get_v2_empty_payload_returns_none(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        result = fs.recipe_get_v2("42")
+    assert result is None
+
+
+# =========================================================================
+# recipes.search v1
+# =========================================================================
+
+
+def test_recipes_search_v1_happy_path(fs):
+    payload = {
+        "recipes": {"recipe": [{"recipe_id": "1"}, {"recipe_id": "2"}]}
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipes_search_v1(
+            search_expression="cake",
+            recipe_type="Dessert",
+            page_number=0,
+            max_results=10,
+        )
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "recipes.search"
+    assert params["search_expression"] == "cake"
+    assert params["recipe_type"] == "Dessert"
+    assert params["page_number"] == 0
+    assert params["max_results"] == 10
+    assert result == [{"recipe_id": "1"}, {"recipe_id": "2"}]
+
+
+def test_recipes_search_v1_no_optionals_only_method(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipes": {"recipe": []}}
+    ) as mock_call:
+        fs.recipes_search_v1()
+    params = mock_call.call_args.args[0]
+    assert params == {"method": "recipes.search"}
+
+
+def test_recipes_search_v1_single_dict_normalized_to_list(fs):
+    payload = {"recipes": {"recipe": {"recipe_id": "solo"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.recipes_search_v1("cake")
+    assert result == [{"recipe_id": "solo"}]
+
+
+def test_recipes_search_v1_empty_returns_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipes": None}):
+        assert fs.recipes_search_v1("nothing") == []
+
+
+def test_recipes_search_v1_does_not_send_v3_only_params(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipes": {"recipe": []}}
+    ) as mock_call:
+        fs.recipes_search_v1("cake")
+    params = mock_call.call_args.args[0]
+    assert "recipe_types" not in params
+    assert "recipe_types_matchall" not in params
+
+
+# =========================================================================
+# recipes.search v2
+# =========================================================================
+
+
+def test_recipes_search_v2_happy_path_all_optionals(fs):
+    payload = {"recipes": {"recipe": [{"recipe_id": "9"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipes_search_v2(
+            search_expression="chicken",
+            must_have_images=True,
+            calories_from=100,
+            calories_to=400,
+            carb_percentage_from=10,
+            carb_percentage_to=40,
+            protein_percentage_from=20,
+            protein_percentage_to=50,
+            fat_percentage_from=5,
+            fat_percentage_to=30,
+            prep_time_from=5,
+            prep_time_to=60,
+            page_number=1,
+            max_results=20,
+            sort_by="newest",
+            region="US",
+        )
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "recipes.search.v2"
+    assert params["search_expression"] == "chicken"
+    assert params["must_have_images"] is True
+    # Dotted keys (upstream API format) are preserved.
+    assert params["calories.from"] == 100
+    assert params["calories.to"] == 400
+    assert params["carb_percentage.from"] == 10
+    assert params["carb_percentage.to"] == 40
+    assert params["protein_percentage.from"] == 20
+    assert params["protein_percentage.to"] == 50
+    assert params["fat_percentage.from"] == 5
+    assert params["fat_percentage.to"] == 30
+    assert params["prep_time.from"] == 5
+    assert params["prep_time.to"] == 60
+    assert params["page_number"] == 1
+    assert params["max_results"] == 20
+    assert params["sort_by"] == "newest"
+    assert params["region"] == "US"
+    assert result == [{"recipe_id": "9"}]
+
+
+def test_recipes_search_v2_no_optionals_only_method(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipes": {"recipe": []}}
+    ) as mock_call:
+        fs.recipes_search_v2()
+    params = mock_call.call_args.args[0]
+    assert params == {"method": "recipes.search.v2"}
+
+
+def test_recipes_search_v2_single_dict_normalized_to_list(fs):
+    payload = {"recipes": {"recipe": {"recipe_id": "x"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.recipes_search_v2("x")
+    assert result == [{"recipe_id": "x"}]
+
+
+def test_recipes_search_v2_empty_returns_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipes": None}):
+        assert fs.recipes_search_v2() == []
+
+
+def test_recipes_search_v2_premier_propagation_via_kwargs(fs):
+    """Premier flag is forwarded to _call via kwargs (any kwarg user passes)."""
+    # The wrapper does not own a premier kwarg, but kwargs given to _call when
+    # the caller injects premier should pass through unchanged. We assert the
+    # public method itself uses no surprise kwargs (no method=POST etc.).
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipes": {"recipe": []}}
+    ) as mock_call:
+        fs.recipes_search_v2("x")
+    # Premier endpoints are GET; no HTTP verb override is set.
+    assert mock_call.call_args.kwargs == {}
+
+
+def test_recipes_search_v2_does_not_send_v3_only_params(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipes": {"recipe": []}}
+    ) as mock_call:
+        fs.recipes_search_v2("x")
+    params = mock_call.call_args.args[0]
+    assert "recipe_types" not in params
+    assert "recipe_types_matchall" not in params
+
+
+# =========================================================================
+# recipes.search v3
+# =========================================================================
+
+
+def test_recipes_search_v3_happy_path_all_optionals(fs):
+    payload = {"recipes": {"recipe": [{"recipe_id": "v3"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipes_search_v3(
+            search_expression="soup",
+            recipe_types="Lunch,Dinner",
+            recipe_types_matchall=True,
+            must_have_images=False,
+            calories_from=50,
+            calories_to=500,
+            carb_percentage_from=10,
+            carb_percentage_to=40,
+            protein_percentage_from=10,
+            protein_percentage_to=50,
+            fat_percentage_from=5,
+            fat_percentage_to=35,
+            prep_time_from=10,
+            prep_time_to=90,
+            page_number=2,
+            max_results=15,
+            sort_by="caloriesAsc",
+            region="GB",
+        )
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "recipes.search.v3"
+    assert params["recipe_types"] == "Lunch,Dinner"
+    assert params["recipe_types_matchall"] is True
+    assert params["search_expression"] == "soup"
+    assert params["must_have_images"] is False
+    assert params["calories.from"] == 50
+    assert params["calories.to"] == 500
+    assert params["region"] == "GB"
+    assert result == [{"recipe_id": "v3"}]
+
+
+def test_recipes_search_v3_no_optionals_only_method(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipes": {"recipe": []}}
+    ) as mock_call:
+        fs.recipes_search_v3()
+    params = mock_call.call_args.args[0]
+    assert params == {"method": "recipes.search.v3"}
+
+
+def test_recipes_search_v3_recipe_types_alone(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipes": {"recipe": []}}
+    ) as mock_call:
+        fs.recipes_search_v3(recipe_types="Breakfast")
+    params = mock_call.call_args.args[0]
+    assert params["recipe_types"] == "Breakfast"
+    assert "recipe_types_matchall" not in params
+
+
+def test_recipes_search_v3_recipe_types_matchall_alone(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipes": {"recipe": []}}
+    ) as mock_call:
+        fs.recipes_search_v3(recipe_types_matchall=False)
+    params = mock_call.call_args.args[0]
+    assert params["recipe_types_matchall"] is False
+    assert "recipe_types" not in params
+
+
+def test_recipes_search_v3_single_dict_normalized_to_list(fs):
+    payload = {"recipes": {"recipe": {"recipe_id": "only"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.recipes_search_v3()
+    assert result == [{"recipe_id": "only"}]
+
+
+def test_recipes_search_v3_empty_returns_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipes": None}):
+        assert fs.recipes_search_v3() == []
+
+
+# =========================================================================
+# recipe_types.get v1
+# =========================================================================
+
+
+def test_recipe_types_get_v1_happy_path(fs):
+    payload = {"recipe_types": {"recipe_type": ["Breakfast", "Lunch", "Dinner"]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipe_types_get_v1()
+    params = mock_call.call_args.args[0]
+    assert params == {"method": "recipe_types.get"}
+    assert mock_call.call_args.kwargs == {}
+    assert result == ["Breakfast", "Lunch", "Dinner"]
+
+
+def test_recipe_types_get_v1_single_value_normalized_to_list(fs):
+    payload = {"recipe_types": {"recipe_type": "Breakfast"}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.recipe_types_get_v1() == ["Breakfast"]
+
+
+def test_recipe_types_get_v1_empty_returns_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipe_types": None}):
+        assert fs.recipe_types_get_v1() == []
+
+
+# =========================================================================
+# recipe_types.get v2
+# =========================================================================
+
+
+def test_recipe_types_get_v2_happy_path_no_opts(fs):
+    payload = {"recipe_types": {"recipe_type": ["A", "B"]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipe_types_get_v2()
+    params = mock_call.call_args.args[0]
+    assert params == {"method": "recipe_types.get.v2"}
+    assert result == ["A", "B"]
+
+
+def test_recipe_types_get_v2_optionals_present_when_set(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipe_types": {"recipe_type": []}}
+    ) as mock_call:
+        fs.recipe_types_get_v2(region="US", language="en")
+    params = mock_call.call_args.args[0]
+    assert params["region"] == "US"
+    assert params["language"] == "en"
+
+
+def test_recipe_types_get_v2_optionals_absent_when_none(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipe_types": {"recipe_type": []}}
+    ) as mock_call:
+        fs.recipe_types_get_v2()
+    params = mock_call.call_args.args[0]
+    assert "region" not in params
+    assert "language" not in params
+
+
+def test_recipe_types_get_v2_partial_optional(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"recipe_types": {"recipe_type": []}}
+    ) as mock_call:
+        fs.recipe_types_get_v2(language="fr")
+    params = mock_call.call_args.args[0]
+    assert params["language"] == "fr"
+    assert "region" not in params
+
+
+def test_recipe_types_get_v2_empty_returns_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={}):
+        assert fs.recipe_types_get_v2() == []
+
+
+# =========================================================================
+# recipe.add_favorite v1
+# =========================================================================
+
+
+def test_recipe_add_favorite_v1_uses_singular_method_name(fs):
+    """Legacy plural typo was `recipes.add_favorites`. v1 fixes to `recipe.add_favorite`."""
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipe_add_favorite_v1("rid-1")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "recipe.add_favorite"
+    assert params["method"] != "recipes.add_favorites"
+    assert params["recipe_id"] == "rid-1"
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    assert result is True
+
+
+def test_recipe_add_favorite_v1_success_string_one(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": "1"}):
+        assert fs.recipe_add_favorite_v1("rid-1") is True
+
+
+def test_recipe_add_favorite_v1_success_zero_is_false(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 0}):
+        assert fs.recipe_add_favorite_v1("rid-1") is False
+
+
+def test_recipe_add_favorite_v1_passthrough_when_no_success_key(fs):
+    payload = {"error": "nope"}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.recipe_add_favorite_v1("rid-1") == payload
+
+
+# =========================================================================
+# recipe.delete_favorite v1
+# =========================================================================
+
+
+def test_recipe_delete_favorite_v1_uses_singular_method_name_and_delete_verb(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipe_delete_favorite_v1("rid-2")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "recipe.delete_favorite"
+    assert params["method"] != "recipes.delete_favorites"
+    assert params["recipe_id"] == "rid-2"
+    assert mock_call.call_args.kwargs.get("method") == "DELETE"
+    assert result is True
+
+
+def test_recipe_delete_favorite_v1_success_string_one(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": "1"}):
+        assert fs.recipe_delete_favorite_v1("rid-2") is True
+
+
+def test_recipe_delete_favorite_v1_passthrough_when_no_success_key(fs):
+    payload = {"unexpected": True}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.recipe_delete_favorite_v1("rid-2") == payload
+
+
+# =========================================================================
+# recipes.get_favorites v1
+# =========================================================================
+
+
+def test_recipes_get_favorites_v1_happy_path(fs):
+    """v1 uses the legacy api method `recipe.get_favorites` (singular root)."""
+    payload = {
+        "recipes": {"recipe": [{"recipe_id": "f1"}, {"recipe_id": "f2"}]}
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipes_get_favorites_v1()
+    params = mock_call.call_args.args[0]
+    assert params == {"method": "recipe.get_favorites"}
+    assert mock_call.call_args.kwargs == {}
+    assert result == [{"recipe_id": "f1"}, {"recipe_id": "f2"}]
+
+
+def test_recipes_get_favorites_v1_single_dict_normalized_to_list(fs):
+    payload = {"recipes": {"recipe": {"recipe_id": "solo"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.recipes_get_favorites_v1() == [{"recipe_id": "solo"}]
+
+
+def test_recipes_get_favorites_v1_empty_returns_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipes": None}):
+        assert fs.recipes_get_favorites_v1() == []
+
+
+# =========================================================================
+# recipes.get_favorites v2
+# =========================================================================
+
+
+def test_recipes_get_favorites_v2_happy_path(fs):
+    payload = {"recipes": {"recipe": [{"recipe_id": "v2a"}]}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.recipes_get_favorites_v2()
+    params = mock_call.call_args.args[0]
+    assert params == {"method": "recipe.get_favorites.v2"}
+    assert mock_call.call_args.kwargs == {}
+    assert result == [{"recipe_id": "v2a"}]
+
+
+def test_recipes_get_favorites_v2_single_dict_normalized_to_list(fs):
+    payload = {"recipes": {"recipe": {"recipe_id": "only"}}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        assert fs.recipes_get_favorites_v2() == [{"recipe_id": "only"}]
+
+
+def test_recipes_get_favorites_v2_empty_returns_list(fs):
+    with patch.object(Fatsecret, "_call", return_value={"recipes": None}):
+        assert fs.recipes_get_favorites_v2() == []

--- a/tests/unit/endpoints/test_weight_profile.py
+++ b/tests/unit/endpoints/test_weight_profile.py
@@ -1,0 +1,323 @@
+"""Exhaustive unit tests for Weight + Profile resource wrappers.
+
+Covers:
+  - weight_update_v1
+  - weights_get_month_v1, _v2
+  - profile_create_v1
+  - profile_get_v1
+  - profile_get_auth_v1
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fatsecret import Fatsecret
+
+
+@pytest.fixture
+def fs():
+    with patch("fatsecret.fatsecret.OAuth1Service") as mock_oauth1:
+        mock_oauth1.return_value.get_session.return_value = MagicMock()
+        return Fatsecret("ck", "cs")
+
+
+# --------------------------- weight.update v1 ---------------------------
+
+
+def test_weight_update_v1_minimal_required(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.weight_update_v1(70.5)
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "weight.update"
+    assert params["current_weight_kg"] == 70.5
+    # No optionals when not supplied
+    assert "weight_type" not in params
+    assert "height_type" not in params
+    assert "goal_weight_kg" not in params
+    assert "current_height_cm" not in params
+    assert "comment" not in params
+    assert "date" not in params
+    # POST verb
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    assert result is True
+
+
+def test_weight_update_v1_success_string_one(fs):
+    """_mutator_success should also accept the string '1'."""
+    with patch.object(Fatsecret, "_call", return_value={"success": "1"}):
+        assert fs.weight_update_v1(70.0) is True
+
+
+def test_weight_update_v1_success_zero_is_false(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 0}):
+        assert fs.weight_update_v1(70.0) is False
+
+
+def test_weight_update_v1_all_optional_params(fs):
+    payload = {"success": 1}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        fs.weight_update_v1(
+            72.0,
+            weight_type="kg",
+            height_type="cm",
+            goal_weight_kg=68.0,
+            current_height_cm=175.0,
+            comment="hello",
+        )
+    params = mock_call.call_args.args[0]
+    assert params["weight_type"] == "kg"
+    assert params["height_type"] == "cm"
+    assert params["goal_weight_kg"] == 68.0
+    assert params["current_height_cm"] == 175.0
+    assert params["comment"] == "hello"
+
+
+def test_weight_update_v1_first_weighin_requires_goal_and_height(fs):
+    """The first weigh-in requires goal_weight_kg and current_height_cm.
+
+    Wrapper must accept and forward both.
+    """
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.weight_update_v1(70.0, goal_weight_kg=65.0, current_height_cm=180.0)
+    params = mock_call.call_args.args[0]
+    assert params["goal_weight_kg"] == 65.0
+    assert params["current_height_cm"] == 180.0
+
+
+@pytest.mark.parametrize(
+    "date_in",
+    [
+        datetime.datetime(2024, 1, 15),
+        datetime.date(2024, 1, 15),
+        1705276800,  # int unix timestamp
+        1705276800.0,  # float unix timestamp
+    ],
+)
+def test_weight_update_v1_date_coercion_accepts_all_types(fs, date_in):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.weight_update_v1(70.0, date=date_in)
+    params = mock_call.call_args.args[0]
+    assert "date" in params
+    # unix_time_v2 returns days since epoch (int)
+    assert isinstance(params["date"], int)
+
+
+def test_weight_update_v1_date_none_omitted(fs):
+    with patch.object(Fatsecret, "_call", return_value={"success": 1}) as mock_call:
+        fs.weight_update_v1(70.0, date=None)
+    params = mock_call.call_args.args[0]
+    assert "date" not in params
+
+
+# --------------------------- weights.get_month v1 ---------------------------
+
+
+def _month_payload(days):
+    return {"month": {"day": days}}
+
+
+def test_weights_get_month_v1_method_and_no_date(fs):
+    payload = _month_payload([{"date_int": "20000", "weight_kg": "70"}])
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.weights_get_month_v1()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "weights.get_month"
+    assert "date" not in params
+    # GET verb (no `method=` kwarg means default GET path)
+    assert mock_call.call_args.kwargs.get("method") in (None, "GET")
+    assert result == [{"date_int": "20000", "weight_kg": "70"}]
+
+
+def test_weights_get_month_v1_single_dict_coerced_to_list(fs):
+    payload = _month_payload({"date_int": "20000", "weight_kg": "70"})
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.weights_get_month_v1()
+    assert result == [{"date_int": "20000", "weight_kg": "70"}]
+
+
+def test_weights_get_month_v1_list_passthrough(fs):
+    days = [{"date_int": "20000"}, {"date_int": "20001"}]
+    with patch.object(Fatsecret, "_call", return_value=_month_payload(days)):
+        result = fs.weights_get_month_v1()
+    assert result == days
+
+
+def test_weights_get_month_v1_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={"month": None}):
+        result = fs.weights_get_month_v1()
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    "date_in",
+    [
+        datetime.datetime(2024, 1, 15),
+        datetime.date(2024, 1, 15),
+        1705276800,
+        1705276800.0,
+    ],
+)
+def test_weights_get_month_v1_date_coercion(fs, date_in):
+    with patch.object(
+        Fatsecret, "_call", return_value=_month_payload([])
+    ) as mock_call:
+        fs.weights_get_month_v1(date=date_in)
+    params = mock_call.call_args.args[0]
+    assert isinstance(params["date"], int)
+
+
+# --------------------------- weights.get_month v2 ---------------------------
+
+
+def test_weights_get_month_v2_method_name(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value=_month_payload([])
+    ) as mock_call:
+        result = fs.weights_get_month_v2()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "weights.get_month.v2"
+    assert result == []
+
+
+def test_weights_get_month_v2_single_dict_coerced(fs):
+    payload = _month_payload({"date_int": "20100", "weight_kg": "68"})
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.weights_get_month_v2()
+    assert result == [{"date_int": "20100", "weight_kg": "68"}]
+
+
+def test_weights_get_month_v2_list_passthrough(fs):
+    days = [{"date_int": "20100"}, {"date_int": "20101"}]
+    with patch.object(Fatsecret, "_call", return_value=_month_payload(days)):
+        result = fs.weights_get_month_v2()
+    assert result == days
+
+
+def test_weights_get_month_v2_empty_response(fs):
+    with patch.object(Fatsecret, "_call", return_value={"month": None}):
+        assert fs.weights_get_month_v2() == []
+
+
+@pytest.mark.parametrize(
+    "date_in",
+    [
+        datetime.datetime(2024, 6, 1),
+        datetime.date(2024, 6, 1),
+        1717200000,
+        1717200000.0,
+    ],
+)
+def test_weights_get_month_v2_date_coercion(fs, date_in):
+    with patch.object(
+        Fatsecret, "_call", return_value=_month_payload([])
+    ) as mock_call:
+        fs.weights_get_month_v2(date=date_in)
+    params = mock_call.call_args.args[0]
+    assert isinstance(params["date"], int)
+
+
+# --------------------------- profile.create v1 ---------------------------
+
+
+def test_profile_create_v1_no_user_id(fs):
+    payload = {"profile": {"auth_token": "tok", "auth_secret": "sec"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.profile_create_v1()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "profile.create"
+    assert "user_id" not in params
+    assert mock_call.call_args.kwargs.get("method") == "POST"
+    # back-compat tuple, NOT dict
+    assert isinstance(result, tuple)
+    assert result == ("tok", "sec")
+
+
+def test_profile_create_v1_with_user_id(fs):
+    payload = {"profile": {"auth_token": "t2", "auth_secret": "s2"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.profile_create_v1(user_id="user-42")
+    params = mock_call.call_args.args[0]
+    assert params["user_id"] == "user-42"
+    assert result == ("t2", "s2")
+    assert isinstance(result, tuple)
+
+
+def test_profile_create_v1_without_auth_token_passes_through(fs):
+    """If the response lacks auth_token, return the profile dict as-is."""
+    payload = {"profile": {"some_other_field": "x"}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.profile_create_v1()
+    assert result == {"some_other_field": "x"}
+    assert not isinstance(result, tuple)
+
+
+# --------------------------- profile.get v1 ---------------------------
+
+
+def test_profile_get_v1_returns_profile_dict(fs):
+    payload = {
+        "profile": {
+            "nickname": "alice",
+            "is_premier": "false",
+            "last_weight_date_int": "20000",
+        }
+    }
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.profile_get_v1()
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "profile.get"
+    # No POST kwarg => default GET path
+    assert mock_call.call_args.kwargs.get("method") in (None, "GET")
+    assert result == {
+        "nickname": "alice",
+        "is_premier": "false",
+        "last_weight_date_int": "20000",
+    }
+    assert isinstance(result, dict)
+
+
+def test_profile_get_v1_no_arguments(fs):
+    with patch.object(
+        Fatsecret, "_call", return_value={"profile": {"nickname": "n"}}
+    ) as mock_call:
+        fs.profile_get_v1()
+    params = mock_call.call_args.args[0]
+    # Only method key
+    assert list(params.keys()) == ["method"]
+
+
+# --------------------------- profile.get_auth v1 ---------------------------
+
+
+def test_profile_get_auth_v1_returns_tuple(fs):
+    payload = {"profile": {"auth_token": "atk", "auth_secret": "ask"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.profile_get_auth_v1(user_id="user-7")
+    params = mock_call.call_args.args[0]
+    assert params["method"] == "profile.get_auth"
+    assert params["user_id"] == "user-7"
+    # default verb (GET)
+    assert mock_call.call_args.kwargs.get("method") in (None, "GET")
+    assert isinstance(result, tuple)
+    assert result == ("atk", "ask")
+
+
+def test_profile_get_auth_v1_without_user_id(fs):
+    payload = {"profile": {"auth_token": "a", "auth_secret": "b"}}
+    with patch.object(Fatsecret, "_call", return_value=payload) as mock_call:
+        result = fs.profile_get_auth_v1()
+    params = mock_call.call_args.args[0]
+    assert "user_id" not in params
+    assert result == ("a", "b")
+
+
+def test_profile_get_auth_v1_without_auth_token_passes_through(fs):
+    """If the response lacks auth_token, fall back to raw profile dict."""
+    payload = {"profile": {"nickname": "noauth"}}
+    with patch.object(Fatsecret, "_call", return_value=payload):
+        result = fs.profile_get_auth_v1(user_id="u")
+    assert result == {"nickname": "noauth"}
+    assert not isinstance(result, tuple)


### PR DESCRIPTION
## Summary

Adds per-resource test files covering every documented (method, version) pair in the v1.0 surface. Companion to the upcoming v2.0 codegen work — these tests are the invariant that any restructure must preserve.

**Coverage on \`src/fatsecret/fatsecret.py\`: 69% → 98%.** 814 unit tests passing (up from 141). Only \`fatsecret_authenticate\` HTML-form scraping remains uncovered (excluded per agreement — needs live FatSecret HTML).

## Test layout

\`tests/unit/endpoints/\`:

| File | Tests | Scope |
|---|---|---|
| test_foods.py | 129 + 18 skipped | foods.search v1-v5, food.get v1-v5, autocomplete, barcode |
| test_classification.py | 52 | brands/categories/sub_categories v1+v2 |
| test_recipes.py | 46 | recipe.get, recipes.search, types, favorites |
| test_profile_foods.py | 139 | food.create v1/v2, favorites, eaten lists |
| test_diary.py | 70 | food_entry CRUD + entries get/get_month |
| test_exercises.py | 40 | exercises.get, entries, edit, commit_day, save_template |
| test_weight_profile.py | 34 | weight.update, weights.get_month, profile.* |
| test_meals.py | 36 | saved_meals + items CRUD + get |
| test_native.py | 63 | NLP, image-recognition v1/v2, feedback |
| test_client_core.py | 65 | _call, _unwrap, api_url, OAuth1 session_token, HMAC signing, valid_response legacy |

All tests use mocked \`_call\` — no real HTTP. Date-bearing methods verify all 4 coercion inputs (datetime/date/int/float). Mutator semantics verified for every \`{success: 1} → True\` path. Single-vs-list normalization verified on every endpoint that uses \`list_key\`.

Renamed \`tests/unit/coverage/\` → \`tests/unit/endpoints/\` to avoid shadowing the \`coverage\` package used by pytest-cov.

## Test plan

- [ ] Lint passes
- [ ] Sphinx docs build clean
- [ ] All 814 unit tests pass
- [ ] Pre-existing flake \`test_authenticate_with_valid_credentials\` may pass or fail depending on real-credentials availability — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)