### PR TITLE
feat(docs): multi-version doc deployment via sphinx-multiversion

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,11 +4,20 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v*.*.*"
 
 permissions:
   contents: read
   pages: write
   id-token: write
+
+# Allow one in-flight Pages deploy at a time. Newer pushes wait for the
+# previous one rather than cancel it, so tag pushes immediately following
+# a master push still produce a complete redeploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -16,6 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + all tags are required: sphinx-multiversion
+          # checks out each whitelisted ref into a worktree and builds it.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
@@ -27,8 +40,41 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Build Sphinx docs
-        run: make docs
+      - name: Build all doc versions
+        run: |
+          rm -rf docs/_build
+          uv run sphinx-multiversion docs docs/_build/html
+
+      - name: Write root index.html redirect to latest stable
+        run: |
+          # Latest stable = highest semver tag matching the same regex as
+          # docs/conf.py's smv_tag_whitelist. Falls back to master if no
+          # whitelisted tag was built (shouldn't happen post-v0.13.0).
+          LATEST=$(find docs/_build/html -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
+            | grep -E '^v(0\.(1[3-9]|[2-9][0-9])|[1-9][0-9]*\.[0-9]+)\.[0-9]+$' \
+            | sort -V \
+            | tail -1)
+          TARGET="${LATEST:-master}"
+          echo "Redirecting / -> /${TARGET}/"
+          cat > docs/_build/html/index.html <<EOF
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <title>fatsecret documentation</title>
+              <meta http-equiv="refresh" content="0; url=${TARGET}/">
+              <link rel="canonical" href="${TARGET}/">
+            </head>
+            <body>
+              <p>Redirecting to the
+                 <a href="${TARGET}/">latest fatsecret docs (${TARGET})</a>.
+              </p>
+            </body>
+          </html>
+          EOF
+
+      - name: List built versions
+        run: ls -1 docs/_build/html
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,0 +1,41 @@
+{# Version dropdown rendered by sphinx-multiversion in the sidebar.
+   `current_version` and `versions` are injected by the plugin. When the
+   plugin is absent (single-version `make docs` build) those globals are
+   undefined and the entire block is skipped, so this template is a no-op
+   in that case. #}
+{%- if current_version -%}
+<div class="rst-versions" data-toggle="rst-versions" role="note"
+     aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Other Versions</span>
+    v: {{ current_version.name }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {%- if versions.branches %}
+    <dl>
+      <dt>Branches</dt>
+      {%- for item in versions.branches %}
+      <dd>
+        <a href="{{ '../' ~ item.name ~ '/' ~ pagename ~ '.html' }}">
+          {{ item.name }}
+        </a>
+      </dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+    {%- if versions.tags %}
+    <dl>
+      <dt>Releases</dt>
+      {%- for item in versions.tags %}
+      <dd>
+        <a href="{{ '../' ~ item.name ~ '/' ~ pagename ~ '.html' }}">
+          {{ item.name }}
+        </a>
+      </dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+  </div>
+</div>
+{%- endif -%}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,41 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
+# Load sphinx_multiversion's extension when it's installed so each per-tag
+# build receives the `current_version` / `versions` Jinja context used by
+# our `_templates/versions.html` dropdown. We import lazily so a single-
+# version `make docs` build still works on machines that haven't installed
+# the dev dependency yet.
+try:
+    import sphinx_multiversion  # noqa: F401
+except ImportError:
+    pass
+else:
+    extensions.append("sphinx_multiversion")
+
 exclude_patterns = ["_build"]
 add_module_names = False
 
 html_theme = "sphinx_rtd_theme"
+
+# -- sphinx-multiversion configuration ---------------------------------------
+# Only build docs for stable release tags (vMAJOR.MINOR.PATCH) and the master
+# branch. Older 0.x tags (v0.2.3..v0.12.0) used a pre-OAS docs layout
+# (api_docs.rst / contents.rst.inc) and an older source tree that cannot be
+# imported under the current Python 3.11 / dependency floor; they are therefore
+# excluded. The minimum supported tag is v0.13.0, which is the first release
+# whose docs/ tree matches the current single-page api.rst layout.
+smv_tag_whitelist = r"^v(0\.(1[3-9]|[2-9]\d)|[1-9]\d*\.\d+)\.\d+$"
+smv_branch_whitelist = r"^master$"
+smv_remote_whitelist = None  # only consider local refs
+smv_released_pattern = r"^refs/tags/v\d+\.\d+\.\d+$"
+smv_outputdir_format = "{ref.name}"
+smv_prefer_remote_refs = False
+
+# Register our `versions.html` template so sphinx_rtd_theme's layout.html
+# (which already does `{% include "versions.html" %}` at the bottom of the
+# page body) picks up our version dropdown. We deliberately do NOT set
+# `html_sidebars` here: the RTD theme renders the dropdown as a floating
+# element from layout.html, and overriding sidebars would clobber the
+# theme's built-in navigation pane.
+templates_path = ["_templates"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,5 @@ dev = [
     "ruff",
     "sphinx-rtd-theme>=3.0.2",
     "sphinx>=7.4.7",
+    "sphinx-multiversion>=0.2.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "fatsecret"
-version = "0.5.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "bs4" },
@@ -302,6 +302,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "sphinx" },
+    { name = "sphinx-multiversion" },
     { name = "sphinx-rtd-theme" },
 ]
 
@@ -322,6 +323,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "sphinx", specifier = ">=7.4.7" },
+    { name = "sphinx-multiversion", specifier = ">=0.2.4" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
 ]
 
@@ -778,6 +780,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
+]
+
+[[package]]
+name = "sphinx-multiversion"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/10/25231164a97a9016bdc73a3530af8f4a6846bdc564af1460af2ff3e59a50/sphinx-multiversion-0.2.4.tar.gz", hash = "sha256:5cd1ca9ecb5eed63cb8d6ce5e9c438ca13af4fa98e7eb6f376be541dd4990bcb", size = 7024, upload-time = "2020-08-12T15:48:20.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/51/203bb30b3ce76373237288e92cb71fb66f80ee380473f36bfe8a9d299c5d/sphinx_multiversion-0.2.4-py2.py3-none-any.whl", hash = "sha256:5c38d5ce785a335d8c8d768b46509bd66bfb9c6252b93b700ca8c05317f207d6", size = 9597, upload-time = "2024-10-03T21:45:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ad/4989e6be165805694e93d09bc57425aa1368273b7de4fe3083fe4310803a/sphinx_multiversion-0.2.4-py3-none-any.whl", hash = "sha256:dec29f2a5890ad68157a790112edc0eb63140e70f9df0a363743c6258fbeb478", size = 9642, upload-time = "2020-08-12T15:48:19.649Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace the single-version GitHub Pages deploy with **sphinx-multiversion**
so every released tag gets its own browsable doc URL, with a sidebar
dropdown for switching between versions.

URL layout after this lands:

- `https://chocotonic.github.io/pyfatsecret/`           -> redirects to highest stable tag
- `https://chocotonic.github.io/pyfatsecret/master/`    -> latest master
- `https://chocotonic.github.io/pyfatsecret/v0.13.0/`   -> docs as they shipped in v0.13.0
- `https://chocotonic.github.io/pyfatsecret/v0.14.0/`   -> docs as they shipped in v0.14.0
- `https://chocotonic.github.io/pyfatsecret/v1.0.0/`    -> built automatically on the next tag

## Tags built

The `smv_tag_whitelist` regex is `^v(0\.(1[3-9]|[2-9]\d)|[1-9]\d*\.\d+)\.\d+$`.

Built locally (verified output under `/tmp/multi-docs/`):

| Ref       | Built | Notes                                                                 |
| --------- | ----- | --------------------------------------------------------------------- |
| `master`  | yes   | Has the new `sphinx_multiversion` extension + dropdown template.      |
| `v0.14.0` | yes   | Uses tag's own `docs/api.rst` + `conf.py`.                            |
| `v0.13.0` | yes   | Same; oldest supported tag.                                           |

## Tags excluded (and why)

| Tag(s)               | Reason excluded                                                                                                   |
| -------------------- | ----------------------------------------------------------------------------------------------------------------- |
| `v0.2.3`             | Pre-`pyproject.toml`; the current docs/conf.py reads `_root/pyproject.toml` for `release`, which would crash.     |
| `v0.3.0` - `v0.9.0`  | Pre-OAS docs layout (`api_docs.rst` + `contents.rst.inc`); the source tree does not import under Python 3.11.     |
| `v0.10.0` - `v0.12.0`| Modern docs layout, but the source tree predates the v1.0 multi-version API surface and current dependency floor. |

The regex stays open-ended for the major component, so `v1.0.0`, `v2.0.0`,
etc. are picked up automatically by the next deploy after a release tag is
pushed.

## Version dropdown UX

`sphinx_rtd_theme`'s `layout.html` already does
`{% include "versions.html" %}` near the end of `<body>`. We provide
`docs/_templates/versions.html` which, when `current_version` is injected
by `sphinx-multiversion`, renders a floating bottom-right dropdown:

```
+-----------------------------------+
| Other Versions   v: master   v    |
+-----------------------------------+
|  Branches                         |
|    master                         |
|  Releases                         |
|    v0.14.0                        |
|    v0.13.0                        |
+-----------------------------------+
```

When the plugin is absent (single-version `make docs` build), the template
is a no-op so local builds are unchanged.

## Workflow changes

`.github/workflows/gh-pages.yml`:

- `fetch-depth: 0` so all tags are visible inside the runner.
- Trigger added for `tags: v*.*.*` so pushing a new release rebuilds Pages
  even outside the master push path.
- `concurrency: pages, cancel-in-progress: false` to keep deploys atomic.
- Builds with `sphinx-multiversion docs docs/_build/html`.
- Writes a root `index.html` that `meta refresh`-redirects to the
  highest-semver built tag (`v0.14.0` today, `v1.0.0` after the next
  release), falling back to `master/` if no whitelisted tag is found.

## Migration steps for end-users

End-users do **not** need to change anything. After this lands and the
workflow runs once:

1. `https://chocotonic.github.io/pyfatsecret/` continues to return docs;
   it now redirects to the most recent stable release rather than
   master's tip.
2. To pin to a specific version, link to `.../pyfatsecret/v0.14.0/` (or
   whichever tag they depend on).
3. To always read master, link to `.../pyfatsecret/master/`.

Maintainers: after merging, push any new release tag and the workflow
will automatically add a `vX.Y.Z/` directory + update the redirect.

## Test plan

- [x] `uv run sphinx-multiversion docs /tmp/multi-docs` produces
      `master/`, `v0.13.0/`, `v0.14.0/`, each with its own `index.html`,
      `api.html`, `usage.html`.
- [x] Version dropdown HTML (`class="rst-current-version"`) is present
      in all three builds.
- [x] `make docs` (single-version, `-W` warning gate) still builds clean.
- [x] `make lint` passes.
- [x] `uv run pytest tests/unit` -> 814 passed, 18 skipped (1 network-
      gated auth test fails locally without FatSecret credentials;
      identical behavior on master).
- [ ] GitHub Pages deploy succeeds on merge (verify on CI).

Constraints honored: no changes to `src/fatsecret/`, `tests/`,
`docs/api-spec/`, or the OAS generator.