### PR TITLE
fix(release): honor conventional commits + tag-triggered publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 concurrency:
   group: release
@@ -11,13 +13,20 @@ concurrency:
 
 jobs:
   test:
+    # Skip the test job on tag pushes (a tag is cut from a green-CI'd
+    # commit on master; running again burns minutes and risks flake churn).
+    if: github.ref_type != 'tag'
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
-      test-type: 'all'
+      test-type: "all"
 
   release:
-    needs: test
+    # Branch-push releases wait on `test`. Tag pushes skip it.
+    needs: [test]
+    if: |
+      always() &&
+      (github.ref_type == 'tag' || needs.test.result == 'success')
     runs-on: ubuntu-latest
 
     permissions:
@@ -48,32 +57,87 @@ jobs:
       - name: Compute version
         id: version
         run: |
-          CURRENT=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 | tr -d 'v')
-          MAJOR=$(echo $CURRENT | cut -d. -f1)
-          MINOR=$(echo $CURRENT | cut -d. -f2)
-          PATCH=$(echo $CURRENT | cut -d. -f3)
+          set -euo pipefail
 
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-          IS_DEPENDABOT=${{ github.actor == 'dependabot[bot]' }}
+          # Two trigger modes:
+          #   * tag push (ref_type=tag) — version IS the tag, no bump
+          #   * branch push to master   — derive bump from conventional
+          #                               commits since the latest tag
 
-          if [ "$IS_DEPENDABOT" = "true" ]; then
-            if echo "$COMMIT_MSG" | grep -qi "CVE\|security\|vulnerability"; then
-              NEW="$MAJOR.$MINOR.$((PATCH + 1))"
-            else
-              echo "skip=true" >> $GITHUB_OUTPUT
-              echo "Skipping: dependabot bump without CVE"
-              exit 0
-            fi
-          else
-            NEW="$MAJOR.$((MINOR + 1)).0"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            NEW="${GITHUB_REF_NAME#v}"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "version=${NEW}" >> "$GITHUB_OUTPUT"
+            echo "tag=v${NEW}" >> "$GITHUB_OUTPUT"
+            echo "create_tag=false" >> "$GITHUB_OUTPUT"
+            echo "Tag push: publishing ${NEW} as-is"
+            exit 0
           fi
 
-          echo "skip=false" >> $GITHUB_OUTPUT
-          echo "version=$NEW" >> $GITHUB_OUTPUT
-          echo "tag=v$NEW" >> $GITHUB_OUTPUT
+          # --- branch push: compute next version from commit history ---
+          CURRENT=$(git tag --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | head -1 \
+            | tr -d 'v')
+          if [ -z "${CURRENT}" ]; then
+            CURRENT="0.0.0"
+            RANGE="HEAD"
+          else
+            RANGE="v${CURRENT}..HEAD"
+          fi
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
 
-      - name: Tag release
-        if: steps.version.outputs.skip == 'false'
+          # Union of all commit messages (subject + body) since the latest
+          # tag — a single breaking commit in the range forces a major bump
+          # even if everything else is a patch.
+          COMMITS=$(git log --format='%B%n---commit-boundary---' "${RANGE}")
+
+          IS_DEPENDABOT=${{ github.actor == 'dependabot[bot]' }}
+
+          # Conventional-commit detection (anchored prefixes; prose-safe):
+          #   * `feat!:`, `fix!:`, etc., OR `BREAKING CHANGE:` footer → major
+          #   * `feat:` / `feat(scope):` → minor
+          #   * anything else (fix, docs, test, chore, refactor, perf, …) → patch
+          BUMP="patch"
+          if echo "$COMMITS" | grep -qE '^[a-z]+(\([^)]+\))?!:'; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE '^BREAKING[ -]CHANGE:'; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE '^feat(\([^)]+\))?:'; then
+            BUMP="minor"
+          fi
+
+          if [ "$IS_DEPENDABOT" = "true" ]; then
+            # Dependabot: skip unless commit mentions a security keyword.
+            # When it does, force a PATCH (never minor/major from a bot).
+            if echo "$COMMITS" | grep -qiE 'CVE|security|vulnerability'; then
+              BUMP="patch"
+            else
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "Skipping: dependabot bump without CVE keyword"
+              exit 0
+            fi
+          fi
+
+          case "$BUMP" in
+            major) NEW="$((MAJOR + 1)).0.0" ;;
+            minor) NEW="${MAJOR}.$((MINOR + 1)).0" ;;
+            patch) NEW="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+          esac
+
+          echo "Latest tag: v${CURRENT}"
+          echo "Bump type:  ${BUMP}"
+          echo "Next ver:   v${NEW}"
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "version=${NEW}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEW}" >> "$GITHUB_OUTPUT"
+          echo "create_tag=true" >> "$GITHUB_OUTPUT"
+
+      - name: Tag release (branch push only)
+        if: steps.version.outputs.skip == 'false' && steps.version.outputs.create_tag == 'true'
         run: |
           sed -i "s/version = \"[^\"]*\"/version = \"${{ steps.version.outputs.version }}\"/" pyproject.toml
           git config user.name "github-actions[bot]"
@@ -81,11 +145,20 @@ jobs:
           git tag "${{ steps.version.outputs.tag }}"
           git push https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }} "${{ steps.version.outputs.tag }}"
 
+      - name: Sync pyproject.toml to tag version (tag push only)
+        if: steps.version.outputs.skip == 'false' && steps.version.outputs.create_tag != 'true'
+        run: |
+          # Tag pushes point at historical commits whose `pyproject.toml`
+          # may carry an older version field. Re-sync without committing so
+          # uv publishes the correct version.
+          sed -i "s/version = \"[^\"]*\"/version = \"${{ steps.version.outputs.version }}\"/" pyproject.toml
+
       - name: Create GitHub Release
         if: steps.version.outputs.skip == 'false'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The release workflow always did \`MINOR + 1\` for any non-dependabot merge — regardless of whether the commit was \`feat!:\`, \`BREAKING CHANGE:\`, or \`fix:\`. This silently downgraded the v1.0 multi-version overhaul to v0.16.0.

This PR fixes the bug and enables retroactive correction.

## What changed

- **Conventional-commit bump detection.** Scans every commit message since the latest stable tag for markers (\`feat!:\`, \`BREAKING CHANGE:\`, \`feat:\`, etc.) and picks the highest-precedence bump:
  - \`feat!:\` / \`fix!:\` / \`chore!:\` / \`BREAKING CHANGE:\` → **major**
  - \`feat:\` / \`feat(scope):\` → **minor**
  - everything else (fix, docs, test, chore, refactor, perf, …) → **patch**
- **Tag-triggered publish.** Adds \`push: tags: v[0-9]+.[0-9]+.[0-9]+\` trigger so a manually-created tag (e.g. retroactive \`v1.0.0\` at the commit that should have been v1.0.0) auto-publishes to PyPI.
- **Tag-push test skip.** A tag is cut from a green-CI'd master commit; re-running tests on tag push burns minutes and risks flake churn.
- **Auto-generated release notes** via \`softprops/action-gh-release\`'s \`generate_release_notes\`.

Same dependabot guard (skip unless CVE/security keyword present), but force PATCH (never minor/major from a bot).

## Test plan

- [ ] CI lint + tests pass on this PR (branch push test path).
- [ ] After merge, the workflow's branch-push behavior on the next merge is correctly computed from commit conventional-commit markers.
- [ ] After merge, pushing a manual \`v1.0.0\` tag at commit \`206b35e\` triggers PyPI publish without re-running tests.

## Followups (separate, manual)

- Yank \`v0.16.0\` on PyPI manually (it currently contains the breaking changes mislabeled as a minor).
- Retroactively tag \`v1.0.0\`/\`v1.0.1\`/\`v1.0.2\`/\`v1.1.0\`/\`v1.2.0\` at the appropriate commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)