### PR TITLE
fix(docs): point uv sync at RTD's venv so theme deps install in the right env

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,11 @@ build:
     post_create_environment:
       - pip install uv
     post_install:
-      - uv sync --all-extras --frozen
+      # Install into RTD's pip-managed venv (where `python -m sphinx` runs)
+      # instead of uv's separate `.venv`. Without this, sphinx-rtd-theme
+      # and myst-parser go to the wrong env and the build fails with
+      # `ThemeError: no theme named 'sphinx_rtd_theme' found`.
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --frozen
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: true


### PR DESCRIPTION
## Summary

First RTD build attempts failed with:

\`\`\`
sphinx.errors.ThemeError: no theme named 'sphinx_rtd_theme' found (missing theme.toml?)
\`\`\`

Root cause: RTD creates its own pip-managed venv (\`READTHEDOCS_VIRTUALENV_PATH\`) where \`python -m sphinx\` runs. Our \`post_install\` step ran \`uv sync\` which installs into uv's separate \`.venv\` — a different env. Sphinx couldn't see the theme/myst-parser deps.

Fix: set \`UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH\` so uv installs directly into RTD's venv.

## Test plan

- [ ] CI passes (this is docs-only; existing tests unaffected).
- [ ] After merge, RTD auto-builds \`latest\` and succeeds. Verified via RTD API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)