### PR TITLE
fix(release): idempotent publish + correct PyPI sidebar/README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,8 +189,28 @@ jobs:
           # Re-sync without committing so uv publishes the correct version.
           sed -i "s/version = \"[^\"]*\"/version = \"${{ steps.version.outputs.version }}\"/" pyproject.toml
 
-      - name: Create GitHub Release
+      - name: Check if version already on PyPI
+        id: pypi_check
         if: steps.version.outputs.skip == 'false'
+        run: |
+          # Idempotency: a branch-push run cuts the new tag and pushes it
+          # to origin via RELEASE_PAT. That tag push fires a SECOND workflow
+          # run (the `tags:` trigger). Both runs target the same version.
+          # First one publishes successfully; second one would 400 on PyPI
+          # ("File already exists"). Skip publish when PyPI already has it.
+          VERSION="${{ steps.version.outputs.version }}"
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+            "https://pypi.org/pypi/fatsecret/${VERSION}/json" || true)
+          if [ "${STATUS}" = "200" ]; then
+            echo "PyPI already has fatsecret==${VERSION}; skipping publish."
+            echo "already=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "PyPI does not have ${VERSION} yet (HTTP ${STATUS}); will publish."
+            echo "already=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.skip == 'false' && steps.pypi_check.outputs.already != 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
@@ -199,7 +219,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish to PyPI
-        if: steps.version.outputs.skip == 'false'
+        if: steps.version.outputs.skip == 'false' && steps.pypi_check.outputs.already != 'true'
         run: make release
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,17 +7,11 @@ This library provides a lightweight python wrapper for the Fatsecret API with th
 
 ## Installation
 
-Install the module via pip
-
 ```sh
-$ pip install fatsecret
+pip install fatsecret
 ```
 
-or easy_install::
-
-```sh
-$ easy_install fatsecret
-```
+Requires Python 3.11+.
 
 ## Config
 
@@ -27,21 +21,33 @@ Register for a developer account at [Fatsecret](https://platform.fatsecret.com/a
 
 Fatsecret supports both delegated and public calls. Only through delegated calls can you access Fatsecret user profile data.
 
-If you're only interested in the public data you only require a session to make HTTP requests:
+If you only need public data:
 
 ```py
 from fatsecret import Fatsecret
 
 fs = Fatsecret(consumer_key, consumer_secret)
+foods = fs.foods_search_v5("Tacos")          # current upstream version
+# or, to pin to a specific historical shape:
+foods = fs.foods_search_v1("Tacos")
 ```
 
-Once you have created a session then you can start reading from Fatsecret's public food and recipe database
+Every method carries an explicit `_vN` version suffix matching FatSecret's
+multi-version API. Unsuffixed names (`foods_search`, `food_get`, …) still
+exist as `DeprecationWarning`-emitting aliases and will be removed in
+v2.0. Surface the warnings during development:
+
+```sh
+python -W default::DeprecationWarning:fatsecret your_script.py
+```
+
+For OAuth2 client-credentials (required for Premier / Native endpoints):
 
 ```py
-foods = fs.foods_search("Tacos")
+fs = Fatsecret(client_id, client_secret, auth="oauth2", scopes=["basic", "premier"])
 ```
 
-Refer to the [documentation](https://fatsecret.readthedocs.io/en/latest/) for further examples and detail.
+Refer to the [documentation](https://fatsecret.readthedocs.io/) for further examples and detail.
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ Documentation = "https://fatsecret.readthedocs.io/"
 Source = "https://github.com/ChocoTonic/fatsecret"
 Issues = "https://github.com/ChocoTonic/fatsecret/issues"
 Changelog = "https://github.com/ChocoTonic/fatsecret/releases"
-"Historical docs (pre-v0.13)" = "https://chocotonic.github.io/fatsecret/legacy/"
+"Per-version docs archive" = "https://chocotonic.github.io/fatsecret/"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]


### PR DESCRIPTION
Fixes the duplicate-tag-push self-loop and refreshes stale PyPI metadata.

## Release workflow idempotency

PR #104 hit \`400 File already exists\` on PyPI. Cause:

1. Branch-push workflow run cuts vX.Y.Z, pushes the tag via \`RELEASE_PAT\`, publishes to PyPI.
2. That tag push (made by a user PAT, not \`GITHUB_TOKEN\`) **re-triggers** the workflow under the \`tags:\` branch — second run targets the same version and dies on PyPI's "already exists" check.

Fix: query PyPI before publishing. If \`fatsecret==<version>\` exists, skip Create-Release + Publish-PyPI. Idempotent; the loop self-resolves.

## PyPI sidebar + README cleanup

- \`pyproject.toml [project.urls]\`: rename \`Historical docs (pre-v0.13)\` → \`Per-version docs archive\` and point at the gh-pages root (not \`/legacy/\`).
- README: drop \`easy_install\`, update example to v1.0 surface (\`foods_search_v5\`), add OAuth2 example, add \`python -W\` deprecation hint.

## Test plan

- [ ] CI green.
- [ ] After merge, the auto-triggered tag-push run skips publish cleanly (no error). Verify in Actions logs.
- [ ] PyPI sidebar shows updated links on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)