### PR TITLE
docs: complete drop of Read the Docs — switch to Furo theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,4 +19,4 @@ extensions = [
 exclude_patterns = ["_build"]
 add_module_names = False
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,6 @@ dev = [
     "pytest-cov",
     "pytest",
     "ruff",
-    "sphinx-rtd-theme>=3.0.2",
+    "furo>=2024.8.6",
     "sphinx>=7.4.7",
 ]

--- a/scripts/build-version-docs/build.py
+++ b/scripts/build-version-docs/build.py
@@ -52,7 +52,7 @@ PYPI_PROJECT = "fatsecret"
 
 # Minimal Sphinx pin. Modern Sphinx builds old .rst trees fine as long as we
 # disable autodoc so it never tries to import the package.
-SPHINX_REQUIREMENTS = ["sphinx==7.4.7", "sphinx-rtd-theme==2.0.0"]
+SPHINX_REQUIREMENTS = ["sphinx==7.4.7", "furo==2024.8.6"]
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- #107 removed the RTD *platform* but `sphinx_rtd_theme` remained as the HTML theme, which still ships RTD branding/JS/`_static/` assets.
- This swaps the theme to Furo (modern, RTD-free, dark mode, better navigation) in all three places: `docs/conf.py`, `pyproject.toml` dev deps, and `scripts/build-version-docs/build.py` `SPHINX_REQUIREMENTS`.
- No other config changes needed — Furo is a drop-in `html_theme = "furo"`.

## Test plan
- [x] Smoke-built `v1.5.6`, `v0.15.0`, `latest/` (with autodoc), and `stable/` (redirect) — all succeeded.
- [x] Grepped the built HTML output: 0 references to `readthedocs` or `sphinx_rtd_theme`.
- [ ] CI green.
- [ ] After merge: trigger `workflow_dispatch` on `archive-docs.yml` for a full refresh, then verify `chocotonic.github.io/fatsecret/` renders with Furo across all versions.