### PR TITLE
docs: move version selector into RTD sidebar + point links to stable/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fatsecret
 
 ![status](https://badge.fury.io/py/fatsecret.svg)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://chocotonic.github.io/fatsecret/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://chocotonic.github.io/fatsecret/stable/)
 
 This library provides a lightweight python wrapper for the Fatsecret API with the goal of making it easier to visualize the data retrieved from the API. To that end, this library will usually return lists of identical elements for ease of plotting, discarding extra header fields that the Fatsecret API otherwise includes. All API calls return either a single or list of JSON dictionaries.
 
@@ -47,11 +47,16 @@ For OAuth2 client-credentials (required for Premier / Native endpoints):
 fs = Fatsecret(client_id, client_secret, auth="oauth2", scopes=["basic", "premier"])
 ```
 
-Refer to the [documentation](https://chocotonic.github.io/fatsecret/) for further examples and detail.
+Refer to the [documentation](https://chocotonic.github.io/fatsecret/stable/) for further examples and detail.
 
 ## Documentation
 
-Docs are published to GitHub Pages at [chocotonic.github.io/fatsecret](https://chocotonic.github.io/fatsecret/). Every released tag gets its own permanent URL at `https://chocotonic.github.io/fatsecret/vX.Y.Z/` (e.g. [`v1.5.6`](https://chocotonic.github.io/fatsecret/v1.5.6/), [`v1.4.1`](https://chocotonic.github.io/fatsecret/v1.4.1/), [`v0.5.0`](https://chocotonic.github.io/fatsecret/v0.5.0/)), so version-pinned URLs never 404. See [the all-versions index](https://chocotonic.github.io/fatsecret/) for the full list.
+- **Stable** — [chocotonic.github.io/fatsecret/stable/](https://chocotonic.github.io/fatsecret/stable/) (tracks the highest released tag)
+- **Latest** — [chocotonic.github.io/fatsecret/latest/](https://chocotonic.github.io/fatsecret/latest/) (tracks `master`)
+- **Per-version permalinks** — every released tag is preserved at `https://chocotonic.github.io/fatsecret/vX.Y.Z/` (e.g. [`v1.5.9`](https://chocotonic.github.io/fatsecret/v1.5.9/), [`v1.4.1`](https://chocotonic.github.io/fatsecret/v1.4.1/), [`v0.5.0`](https://chocotonic.github.io/fatsecret/v0.5.0/)) so version-pinned links never 404
+- **All-versions index** — [chocotonic.github.io/fatsecret](https://chocotonic.github.io/fatsecret/)
+
+A version-switcher dropdown sits in the sidebar of every doc page.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://chocotonic.github.io/fatsecret/"
+Documentation = "https://chocotonic.github.io/fatsecret/stable/"
 Source = "https://github.com/ChocoTonic/fatsecret"
 Issues = "https://github.com/ChocoTonic/fatsecret/issues"
 Changelog = "https://github.com/ChocoTonic/fatsecret/releases"

--- a/scripts/build-version-docs/build.py
+++ b/scripts/build-version-docs/build.py
@@ -479,20 +479,46 @@ def inject_version_selector(staging: Path, versions: list[str]) -> int:
   if (!m) return;
   var current = m[1];
   var base = window.location.pathname.substring(0, m.index + 1);
+
+  function buildSelect() {{
+    var sel = document.createElement('select');
+    versions.forEach(function(v) {{
+      var o = document.createElement('option');
+      o.value = v; o.text = v;
+      if (v === current) o.selected = true;
+      sel.appendChild(o);
+    }});
+    sel.onchange = function() {{ window.location.href = base + sel.value + '/'; }};
+    return sel;
+  }}
+
+  // Preferred placement: inside the RTD theme's sidebar header
+  // (`.wy-side-nav-search`), matching where the original RTD flyout
+  // showed the version dropdown for ~10 years of this library's history.
+  var rtdSidebar = document.querySelector('.wy-side-nav-search');
+  if (rtdSidebar) {{
+    var wrap = document.createElement('div');
+    wrap.style.cssText = 'padding:8px 12px;margin-top:4px;text-align:left;background:rgba(0,0,0,0.12);font:12px -apple-system,BlinkMacSystemFont,sans-serif';
+    var label = document.createElement('span');
+    label.textContent = 'Version: ';
+    label.style.cssText = 'color:#fff;margin-right:6px';
+    var sel = buildSelect();
+    sel.style.cssText = 'background:#fff;color:#222;border:none;border-radius:3px;padding:2px 6px;font:inherit;cursor:pointer';
+    wrap.appendChild(label);
+    wrap.appendChild(sel);
+    rtdSidebar.appendChild(wrap);
+    return;
+  }}
+
+  // Fallback: fixed-position dropdown top-right. Covers stub pages and
+  // any future theme without a sidebar we recognise.
   var wrap = document.createElement('div');
   wrap.style.cssText = 'position:fixed;top:0.75rem;right:0.75rem;z-index:9999;background:#fff;color:#222;border:1px solid #ccc;border-radius:6px;padding:6px 10px;box-shadow:0 2px 8px rgba(0,0,0,0.12);font:13px -apple-system,BlinkMacSystemFont,sans-serif';
   var label = document.createElement('span');
   label.textContent = 'Version: ';
   label.style.cssText = 'color:#666;margin-right:4px';
-  var sel = document.createElement('select');
+  var sel = buildSelect();
   sel.style.cssText = 'font:inherit;background:#fff;color:#222;border:1px solid #ccc;border-radius:3px;padding:2px 4px';
-  versions.forEach(function(v) {{
-    var o = document.createElement('option');
-    o.value = v; o.text = v;
-    if (v === current) o.selected = true;
-    sel.appendChild(o);
-  }});
-  sel.onchange = function() {{ window.location.href = base + sel.value + '/'; }};
   wrap.appendChild(label);
   wrap.appendChild(sel);
   document.body.appendChild(wrap);


### PR DESCRIPTION
## Summary

### 1. Version selector now sits in the RTD theme sidebar
Previously injected as a floating top-right widget. Now placed inside `.wy-side-nav-search` (the dark green sidebar header in the RTD theme), matching where the original Read the Docs flyout rendered the version dropdown for ~10 years of this library's history. The floating top-right placement remains as a fallback for stub pages or any future theme without a recognised sidebar element.

### 2. Doc links point to `/stable/` instead of the root index
README badge, README "documentation" link, and `pyproject.toml` `Documentation` URL now point at `/stable/` (which auto-redirects to the highest released tag). Users clicking through from PyPI or the README land directly on usable docs instead of a version listing page. The all-versions index is still linked explicitly in the README's Documentation section for users who do want to browse all versions.

## Test plan
- [x] Smoke-built `v0.3.0/usage.html`, `v1.5.6/`, `latest/`, `stable/` end-to-end.
- [x] Verified `.wy-side-nav-search` exists in legacy-tag output and injection script targets it.
- [ ] CI green.
- [ ] After merge: full refresh, then visit https://chocotonic.github.io/fatsecret/v0.3.0/usage.html and confirm the version dropdown renders in the sidebar header (not top-right).