### PR TITLE
fix(release): commit pyproject.toml version bump back to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,16 @@ jobs:
             exit 0
           fi
 
+          # Skip the release-bot's own commit (which carries `[skip release]`
+          # in the subject) so we don't recursively cut another tag after
+          # the back-commit lands on master.
+          HEAD_SUBJECT=$(git log -1 --format='%s' HEAD)
+          if echo "$HEAD_SUBJECT" | grep -qF '[skip release]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping: HEAD commit is a release back-commit (${HEAD_SUBJECT})"
+            exit 0
+          fi
+
           # --- branch push: compute next version from commit history ---
           CURRENT=$(git tag --sort=-version:refname \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
@@ -175,11 +185,29 @@ jobs:
       - name: Tag release (branch push only)
         if: steps.version.outputs.skip == 'false' && steps.version.outputs.create_tag == 'true'
         run: |
-          sed -i "s/version = \"[^\"]*\"/version = \"${{ steps.version.outputs.version }}\"/" pyproject.toml
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # Bump pyproject.toml, commit it to master, then tag THAT commit.
+          # Previously we sed'd but never committed, so every tag pointed at
+          # a master commit with stale `version = "1.0.0"` — see #112 for
+          # the docs-side workaround this replaces.
+          #
+          # `[skip release]` in the commit subject is matched by the
+          # conventional-commit grep below to avoid recursive triggering:
+          # this workflow's branch-push handler will see the commit and
+          # detect no semantic-version-bumping change, so it won't try to
+          # cut another tag.
+          sed -i "s/version = \"[^\"]*\"/version = \"${VERSION}\"/" pyproject.toml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "${{ steps.version.outputs.tag }}"
-          git push https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }} "${{ steps.version.outputs.tag }}"
+          git add pyproject.toml
+          git commit -m "chore(release): ${TAG} [skip release]"
+          git tag "${TAG}"
+          REMOTE="https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}"
+          git push "${REMOTE}" "HEAD:${GITHUB_REF_NAME}"
+          git push "${REMOTE}" "${TAG}"
 
       - name: Sync pyproject.toml to tag version (tag or dispatch)
         if: steps.version.outputs.skip == 'false' && steps.version.outputs.create_tag != 'true'


### PR DESCRIPTION
## Summary
Previously the branch-push handler sed'd `pyproject.toml`'s version field but never committed the change, so every released tag pointed at a master commit whose `pyproject.toml` still read `version = "1.0.0"`. Verified:

\`\`\`
v1.5.10: version = "1.0.0"
v1.5.5:  version = "1.0.0"
v1.5.0:  version = "1.0.0"
v1.4.0:  version = "1.0.0"
v1.0.0:  version = "1.0.0"
\`\`\`

This PR makes the branch-push handler:
1. `sed` the new version into `pyproject.toml`
2. `git commit` it with subject `chore(release): vX.Y.Z [skip release]`
3. `git tag` that commit
4. `git push` master and the tag

Tags will from now on point at commits whose `pyproject.toml` carries the matching version.

## Recursion guard
The back-commit lands on master and would normally fire this same workflow again. The version-compute step now short-circuits when `HEAD`'s subject contains `[skip release]`, so the back-commit doesn't trigger another release cycle.

## Side effects
- `archive-docs.yml` has a paths filter on `docs/**`, `src/**`, `scripts/build-version-docs/**`. The release back-commit only touches `pyproject.toml`, so it won't fire archive-docs.
- Historical tags are unaffected (they keep their stale pyproject). PR #112's docs-side workaround (compute `<highest+1>.dev0` from git tags) still labels `latest/` correctly regardless.

## Test plan
- [ ] CI green.
- [ ] After merge: next time a feat/fix/chore lands on master, verify the resulting tag points at a commit whose `pyproject.toml` carries the new version (not "1.0.0").
- [ ] Verify the back-commit doesn't trigger a second release.