### PR TITLE
Revert "fix(release): commit pyproject.toml version bump back to master (#113)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,16 +112,6 @@ jobs:
             exit 0
           fi
 
-          # Skip the release-bot's own commit (which carries `[skip release]`
-          # in the subject) so we don't recursively cut another tag after
-          # the back-commit lands on master.
-          HEAD_SUBJECT=$(git log -1 --format='%s' HEAD)
-          if echo "$HEAD_SUBJECT" | grep -qF '[skip release]'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping: HEAD commit is a release back-commit (${HEAD_SUBJECT})"
-            exit 0
-          fi
-
           # --- branch push: compute next version from commit history ---
           CURRENT=$(git tag --sort=-version:refname \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
@@ -185,29 +175,11 @@ jobs:
       - name: Tag release (branch push only)
         if: steps.version.outputs.skip == 'false' && steps.version.outputs.create_tag == 'true'
         run: |
-          set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG="${{ steps.version.outputs.tag }}"
-
-          # Bump pyproject.toml, commit it to master, then tag THAT commit.
-          # Previously we sed'd but never committed, so every tag pointed at
-          # a master commit with stale `version = "1.0.0"` — see #112 for
-          # the docs-side workaround this replaces.
-          #
-          # `[skip release]` in the commit subject is matched by the
-          # conventional-commit grep below to avoid recursive triggering:
-          # this workflow's branch-push handler will see the commit and
-          # detect no semantic-version-bumping change, so it won't try to
-          # cut another tag.
-          sed -i "s/version = \"[^\"]*\"/version = \"${VERSION}\"/" pyproject.toml
+          sed -i "s/version = \"[^\"]*\"/version = \"${{ steps.version.outputs.version }}\"/" pyproject.toml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          git commit -m "chore(release): ${TAG} [skip release]"
-          git tag "${TAG}"
-          REMOTE="https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}"
-          git push "${REMOTE}" "HEAD:${GITHUB_REF_NAME}"
-          git push "${REMOTE}" "${TAG}"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }} "${{ steps.version.outputs.tag }}"
 
       - name: Sync pyproject.toml to tag version (tag or dispatch)
         if: steps.version.outputs.skip == 'false' && steps.version.outputs.create_tag != 'true'


### PR DESCRIPTION
## Why
PR #113 broke the release workflow: master is a protected branch (requires PRs for any change), so the workflow's direct \`git push HEAD:master\` is rejected with \`GH006: Protected branch update failed\`.

Failure log excerpt:
\`\`\`
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> master (protected branch hook declined)
\`\`\`

Result: every master push fails at "Tag release (branch push only)" step, blocking the release pipeline.

This revert restores the previous sed-only behavior. The original "tags point at commits with stale pyproject" problem returns, but the release pipeline works again — that's the more important property right now. PR #112's docs-side workaround still labels \`latest/\` correctly regardless.

## Path forward (not in this PR)
If we want to fix the underlying issue properly: either
1. Have the workflow open a PR with the pyproject bump (more complex, requires auto-merge or manual review).
2. Whitelist \`github-actions[bot]\` in branch protection.
3. Use a separately-permissioned admin token (\`RELEASE_PAT\`) that has branch-protection bypass.

For now this just unblocks releases.

## Test plan
- [ ] CI green.
- [ ] After merge: confirm next master push successfully cuts a tag (the sed-only behavior is the pre-#113 state, which was working).