### PR TITLE
feat(api): v2.0 Phase 1 — resource-namespaced surface

### DIFF
--- a/src/fatsecret/fatsecret.py
+++ b/src/fatsecret/fatsecret.py
@@ -98,6 +98,35 @@ class Fatsecret:
         else:
             raise ValueError(f"auth must be 'oauth1' or 'oauth2', got {auth!r}")
 
+        # v2.0 resource-namespaced surface. Each resource exposes the
+        # OAS-tag's endpoints via short names (e.g. fs.foods.search_v5).
+        # Phase 1: pure delegation over the flat _vN methods on this class.
+        from .resources import (
+            ClassificationResource,
+            DiaryResource,
+            ExercisesResource,
+            FeedbackResource,
+            FoodsResource,
+            MealsResource,
+            NativeResource,
+            ProfileFoodsResource,
+            ProfileResource,
+            RecipesResource,
+            WeightResource,
+        )
+
+        self.foods = FoodsResource(self)
+        self.classification = ClassificationResource(self)
+        self.recipes = RecipesResource(self)
+        self.profile_foods = ProfileFoodsResource(self)
+        self.meals = MealsResource(self)
+        self.diary = DiaryResource(self)
+        self.exercises = ExercisesResource(self)
+        self.weight = WeightResource(self)
+        self.profile = ProfileResource(self)
+        self.native = NativeResource(self)
+        self.feedback = FeedbackResource(self)
+
     def _get_oauth2_token(self) -> str:
         """Fetch (and cache) an OAuth2 bearer token via client_credentials.
 

--- a/src/fatsecret/resources/__init__.py
+++ b/src/fatsecret/resources/__init__.py
@@ -1,0 +1,34 @@
+"""Resource-namespaced API surface for v2.0.
+
+Each resource maps 1:1 to an OAS tag from `docs/api-spec/openapi.yaml`.
+Phase 1 (this commit): pure-delegation wrappers over the flat `_vN`
+methods that already live on `Fatsecret`. No behavior change.
+
+Future phases swap delegation for fully generated implementations.
+"""
+
+from .classification import ClassificationResource
+from .diary import DiaryResource
+from .exercises import ExercisesResource
+from .feedback import FeedbackResource
+from .foods import FoodsResource
+from .meals import MealsResource
+from .native import NativeResource
+from .profile import ProfileResource
+from .profile_foods import ProfileFoodsResource
+from .recipes import RecipesResource
+from .weight import WeightResource
+
+__all__ = [
+    "ClassificationResource",
+    "DiaryResource",
+    "ExercisesResource",
+    "FeedbackResource",
+    "FoodsResource",
+    "MealsResource",
+    "NativeResource",
+    "ProfileFoodsResource",
+    "ProfileResource",
+    "RecipesResource",
+    "WeightResource",
+]

--- a/src/fatsecret/resources/_base.py
+++ b/src/fatsecret/resources/_base.py
@@ -1,0 +1,23 @@
+"""Base class for v2.0 resource-namespaced wrappers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..fatsecret import Fatsecret
+
+
+class BaseResource:
+    """Common scaffold for every resource.
+
+    Resources hold a back-reference to the `Fatsecret` client so they can
+    delegate to its existing flat methods during Phase 1, and to its
+    `_call`/`_check_errors`/`_unwrap` helpers once Phase 5 codegen replaces
+    delegation with real implementations.
+    """
+
+    __slots__ = ("_client",)
+
+    def __init__(self, client: "Fatsecret") -> None:
+        self._client = client

--- a/src/fatsecret/resources/classification.py
+++ b/src/fatsecret/resources/classification.py
@@ -1,0 +1,38 @@
+"""Resource wrapper for the OAS `Food Classification` tag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class ClassificationResource(BaseResource):
+    """Resource methods for the OAS `Food Classification` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def brands_get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_brands_get_v1`."""
+        return self._client.food_brands_get_v1(*args, **kwargs)
+
+    def brands_get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_brands_get_v2`."""
+        return self._client.food_brands_get_v2(*args, **kwargs)
+
+    def categories_get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_categories_get_v1`."""
+        return self._client.food_categories_get_v1(*args, **kwargs)
+
+    def categories_get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_categories_get_v2`."""
+        return self._client.food_categories_get_v2(*args, **kwargs)
+
+    def sub_categories_get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_sub_categories_get_v1`."""
+        return self._client.food_sub_categories_get_v1(*args, **kwargs)
+
+    def sub_categories_get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_sub_categories_get_v2`."""
+        return self._client.food_sub_categories_get_v2(*args, **kwargs)

--- a/src/fatsecret/resources/diary.py
+++ b/src/fatsecret/resources/diary.py
@@ -1,0 +1,50 @@
+"""Food diary resource — food entry CRUD + diary retrieval by day/month."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class DiaryResource(BaseResource):
+    """Resource methods for the OAS `Food Diary` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def entries_copy_saved_meal_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entries_copy_saved_meal_v1`."""
+        return self._client.food_entries_copy_saved_meal_v1(*args, **kwargs)
+
+    def entries_copy_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entries_copy_v1`."""
+        return self._client.food_entries_copy_v1(*args, **kwargs)
+
+    def entries_get_month_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entries_get_month_v1`."""
+        return self._client.food_entries_get_month_v1(*args, **kwargs)
+
+    def entries_get_month_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entries_get_month_v2`."""
+        return self._client.food_entries_get_month_v2(*args, **kwargs)
+
+    def entries_get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entries_get_v1`."""
+        return self._client.food_entries_get_v1(*args, **kwargs)
+
+    def entries_get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entries_get_v2`."""
+        return self._client.food_entries_get_v2(*args, **kwargs)
+
+    def entry_create_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entry_create_v1`."""
+        return self._client.food_entry_create_v1(*args, **kwargs)
+
+    def entry_delete_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entry_delete_v1`."""
+        return self._client.food_entry_delete_v1(*args, **kwargs)
+
+    def entry_edit_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_entry_edit_v1`."""
+        return self._client.food_entry_edit_v1(*args, **kwargs)

--- a/src/fatsecret/resources/exercises.py
+++ b/src/fatsecret/resources/exercises.py
@@ -1,0 +1,50 @@
+"""Exercises resource — exercise diary entries + exercise type catalog."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class ExercisesResource(BaseResource):
+    """Resource methods for the OAS `Exercise Diary` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def entries_commit_day_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercise_entries_commit_day_v1`."""
+        return self._client.exercise_entries_commit_day_v1(*args, **kwargs)
+
+    def entries_get_month_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercise_entries_get_month_v1`."""
+        return self._client.exercise_entries_get_month_v1(*args, **kwargs)
+
+    def entries_get_month_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercise_entries_get_month_v2`."""
+        return self._client.exercise_entries_get_month_v2(*args, **kwargs)
+
+    def entries_get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercise_entries_get_v1`."""
+        return self._client.exercise_entries_get_v1(*args, **kwargs)
+
+    def entries_get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercise_entries_get_v2`."""
+        return self._client.exercise_entries_get_v2(*args, **kwargs)
+
+    def entries_save_template_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercise_entries_save_template_v1`."""
+        return self._client.exercise_entries_save_template_v1(*args, **kwargs)
+
+    def entry_edit_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercise_entry_edit_v1`."""
+        return self._client.exercise_entry_edit_v1(*args, **kwargs)
+
+    def list_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercises_get_v1`."""
+        return self._client.exercises_get_v1(*args, **kwargs)
+
+    def list_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.exercises_get_v2`."""
+        return self._client.exercises_get_v2(*args, **kwargs)

--- a/src/fatsecret/resources/feedback.py
+++ b/src/fatsecret/resources/feedback.py
@@ -1,0 +1,18 @@
+"""Resource wrapper for the OAS `Feedback` tag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class FeedbackResource(BaseResource):
+    """Resource methods for the OAS `Feedback` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def submit_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.feedback_v1`."""
+        return self._client.feedback_v1(*args, **kwargs)

--- a/src/fatsecret/resources/foods.py
+++ b/src/fatsecret/resources/foods.py
@@ -1,0 +1,72 @@
+"""Resource wrapper for the OAS ``Foods`` tag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class FoodsResource(BaseResource):
+    """Resource methods for the OAS `Foods` tag.
+
+    Phase 1: pure-delegation over the flat ``foods_*`` / ``food_*``
+    methods on :class:`Fatsecret`. Future phases swap delegation for
+    OAS-codegen'd implementations.
+    """
+
+    def autocomplete_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_autocomplete_v1`."""
+        return self._client.foods_autocomplete_v1(*args, **kwargs)
+
+    def autocomplete_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_autocomplete_v2`."""
+        return self._client.foods_autocomplete_v2(*args, **kwargs)
+
+    def find_id_for_barcode_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_find_id_for_barcode_v1`."""
+        return self._client.food_find_id_for_barcode_v1(*args, **kwargs)
+
+    def find_id_for_barcode_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_find_id_for_barcode_v2`."""
+        return self._client.food_find_id_for_barcode_v2(*args, **kwargs)
+
+    def get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_get_v1`."""
+        return self._client.food_get_v1(*args, **kwargs)
+
+    def get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_get_v2`."""
+        return self._client.food_get_v2(*args, **kwargs)
+
+    def get_v3(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_get_v3`."""
+        return self._client.food_get_v3(*args, **kwargs)
+
+    def get_v4(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_get_v4`."""
+        return self._client.food_get_v4(*args, **kwargs)
+
+    def get_v5(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_get_v5`."""
+        return self._client.food_get_v5(*args, **kwargs)
+
+    def search_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_search_v1`."""
+        return self._client.foods_search_v1(*args, **kwargs)
+
+    def search_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_search_v2`."""
+        return self._client.foods_search_v2(*args, **kwargs)
+
+    def search_v3(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_search_v3`."""
+        return self._client.foods_search_v3(*args, **kwargs)
+
+    def search_v4(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_search_v4`."""
+        return self._client.foods_search_v4(*args, **kwargs)
+
+    def search_v5(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_search_v5`."""
+        return self._client.foods_search_v5(*args, **kwargs)

--- a/src/fatsecret/resources/meals.py
+++ b/src/fatsecret/resources/meals.py
@@ -1,0 +1,54 @@
+"""Saved meals resource — saved_meal CRUD + saved_meals.get + saved_meal_item CRUD + saved_meal_items.get."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class MealsResource(BaseResource):
+    """Resource methods for the OAS `Saved Meals` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def create_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meal_create_v1`."""
+        return self._client.saved_meal_create_v1(*args, **kwargs)
+
+    def delete_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meal_delete_v1`."""
+        return self._client.saved_meal_delete_v1(*args, **kwargs)
+
+    def edit_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meal_edit_v1`."""
+        return self._client.saved_meal_edit_v1(*args, **kwargs)
+
+    def get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meals_get_v1`."""
+        return self._client.saved_meals_get_v1(*args, **kwargs)
+
+    def get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meals_get_v2`."""
+        return self._client.saved_meals_get_v2(*args, **kwargs)
+
+    def item_add_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meal_item_add_v1`."""
+        return self._client.saved_meal_item_add_v1(*args, **kwargs)
+
+    def item_delete_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meal_item_delete_v1`."""
+        return self._client.saved_meal_item_delete_v1(*args, **kwargs)
+
+    def item_edit_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meal_item_edit_v1`."""
+        return self._client.saved_meal_item_edit_v1(*args, **kwargs)
+
+    def items_get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meal_items_get_v1`."""
+        return self._client.saved_meal_items_get_v1(*args, **kwargs)
+
+    def items_get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.saved_meal_items_get_v2`."""
+        return self._client.saved_meal_items_get_v2(*args, **kwargs)

--- a/src/fatsecret/resources/native.py
+++ b/src/fatsecret/resources/native.py
@@ -1,0 +1,28 @@
+"""Resource wrapper for the OAS ``Native`` tag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class NativeResource(BaseResource):
+    """Resource methods for the OAS `Native` tag.
+
+    Phase 1: pure-delegation over the flat ``natural_language_processing_*``
+    and ``image_recognition_*`` methods on :class:`Fatsecret`. Future phases
+    swap delegation for OAS-codegen'd implementations.
+    """
+
+    def image_recognition_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.image_recognition_v1`."""
+        return self._client.image_recognition_v1(*args, **kwargs)
+
+    def image_recognition_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.image_recognition_v2`."""
+        return self._client.image_recognition_v2(*args, **kwargs)
+
+    def natural_language_processing_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.natural_language_processing_v1`."""
+        return self._client.natural_language_processing_v1(*args, **kwargs)

--- a/src/fatsecret/resources/profile.py
+++ b/src/fatsecret/resources/profile.py
@@ -1,0 +1,26 @@
+"""Resource methods for the OAS ``Profile`` tag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class ProfileResource(BaseResource):
+    """Resource methods for the OAS `Profile` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def create_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.profile_create_v1`."""
+        return self._client.profile_create_v1(*args, **kwargs)
+
+    def get_auth_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.profile_get_auth_v1`."""
+        return self._client.profile_get_auth_v1(*args, **kwargs)
+
+    def get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.profile_get_v1`."""
+        return self._client.profile_get_v1(*args, **kwargs)

--- a/src/fatsecret/resources/profile_foods.py
+++ b/src/fatsecret/resources/profile_foods.py
@@ -1,0 +1,54 @@
+"""Resource methods for the OAS ``Profile Foods`` tag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class ProfileFoodsResource(BaseResource):
+    """Resource methods for the OAS `Profile Foods` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def add_favorite_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_add_favorite_v1`."""
+        return self._client.food_add_favorite_v1(*args, **kwargs)
+
+    def create_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_create_v1`."""
+        return self._client.food_create_v1(*args, **kwargs)
+
+    def create_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_create_v2`."""
+        return self._client.food_create_v2(*args, **kwargs)
+
+    def delete_favorite_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.food_delete_favorite_v1`."""
+        return self._client.food_delete_favorite_v1(*args, **kwargs)
+
+    def get_favorites_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_get_favorites_v1`."""
+        return self._client.foods_get_favorites_v1(*args, **kwargs)
+
+    def get_favorites_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_get_favorites_v2`."""
+        return self._client.foods_get_favorites_v2(*args, **kwargs)
+
+    def get_most_eaten_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_get_most_eaten_v1`."""
+        return self._client.foods_get_most_eaten_v1(*args, **kwargs)
+
+    def get_most_eaten_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_get_most_eaten_v2`."""
+        return self._client.foods_get_most_eaten_v2(*args, **kwargs)
+
+    def get_recently_eaten_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_get_recently_eaten_v1`."""
+        return self._client.foods_get_recently_eaten_v1(*args, **kwargs)
+
+    def get_recently_eaten_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.foods_get_recently_eaten_v2`."""
+        return self._client.foods_get_recently_eaten_v2(*args, **kwargs)

--- a/src/fatsecret/resources/recipes.py
+++ b/src/fatsecret/resources/recipes.py
@@ -1,0 +1,58 @@
+"""Recipes resource — recipe.get, recipes.search, recipe_types.get, recipe favorites."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class RecipesResource(BaseResource):
+    """Resource methods for the OAS `Recipes` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def add_favorite_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipe_add_favorite_v1`."""
+        return self._client.recipe_add_favorite_v1(*args, **kwargs)
+
+    def delete_favorite_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipe_delete_favorite_v1`."""
+        return self._client.recipe_delete_favorite_v1(*args, **kwargs)
+
+    def get_favorites_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipes_get_favorites_v1`."""
+        return self._client.recipes_get_favorites_v1(*args, **kwargs)
+
+    def get_favorites_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipes_get_favorites_v2`."""
+        return self._client.recipes_get_favorites_v2(*args, **kwargs)
+
+    def get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipe_get_v1`."""
+        return self._client.recipe_get_v1(*args, **kwargs)
+
+    def get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipe_get_v2`."""
+        return self._client.recipe_get_v2(*args, **kwargs)
+
+    def search_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipes_search_v1`."""
+        return self._client.recipes_search_v1(*args, **kwargs)
+
+    def search_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipes_search_v2`."""
+        return self._client.recipes_search_v2(*args, **kwargs)
+
+    def search_v3(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipes_search_v3`."""
+        return self._client.recipes_search_v3(*args, **kwargs)
+
+    def types_get_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipe_types_get_v1`."""
+        return self._client.recipe_types_get_v1(*args, **kwargs)
+
+    def types_get_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.recipe_types_get_v2`."""
+        return self._client.recipe_types_get_v2(*args, **kwargs)

--- a/src/fatsecret/resources/weight.py
+++ b/src/fatsecret/resources/weight.py
@@ -1,0 +1,26 @@
+"""Resource wrapper for the OAS `Weight` tag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._base import BaseResource
+
+
+class WeightResource(BaseResource):
+    """Resource methods for the OAS `Weight` tag.
+
+    Phase 1: pure-delegation over flat methods on :class:`Fatsecret`.
+    """
+
+    def get_month_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.weights_get_month_v1`."""
+        return self._client.weights_get_month_v1(*args, **kwargs)
+
+    def get_month_v2(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.weights_get_month_v2`."""
+        return self._client.weights_get_month_v2(*args, **kwargs)
+
+    def update_v1(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`Fatsecret.weight_update_v1`."""
+        return self._client.weight_update_v1(*args, **kwargs)

--- a/tests/unit/test_resources_phase1.py
+++ b/tests/unit/test_resources_phase1.py
@@ -1,0 +1,167 @@
+"""Phase 1 v2.0 resource-surface parity tests.
+
+Every namespaced call (e.g. ``fs.foods.search_v5(...)``) must delegate
+to its flat-method equivalent (``fs.foods_search_v5(...)``) with the
+exact same args/kwargs and return value. This is exhaustive — one
+parametrize case per delegation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from fatsecret import Fatsecret
+
+# (resource_attr, namespaced_method, flat_method_on_client)
+DELEGATIONS: list[tuple[str, str, str]] = [
+    # Foods (14)
+    ("foods", "autocomplete_v1", "foods_autocomplete_v1"),
+    ("foods", "autocomplete_v2", "foods_autocomplete_v2"),
+    ("foods", "find_id_for_barcode_v1", "food_find_id_for_barcode_v1"),
+    ("foods", "find_id_for_barcode_v2", "food_find_id_for_barcode_v2"),
+    ("foods", "get_v1", "food_get_v1"),
+    ("foods", "get_v2", "food_get_v2"),
+    ("foods", "get_v3", "food_get_v3"),
+    ("foods", "get_v4", "food_get_v4"),
+    ("foods", "get_v5", "food_get_v5"),
+    ("foods", "search_v1", "foods_search_v1"),
+    ("foods", "search_v2", "foods_search_v2"),
+    ("foods", "search_v3", "foods_search_v3"),
+    ("foods", "search_v4", "foods_search_v4"),
+    ("foods", "search_v5", "foods_search_v5"),
+    # Classification (6)
+    ("classification", "brands_get_v1", "food_brands_get_v1"),
+    ("classification", "brands_get_v2", "food_brands_get_v2"),
+    ("classification", "categories_get_v1", "food_categories_get_v1"),
+    ("classification", "categories_get_v2", "food_categories_get_v2"),
+    ("classification", "sub_categories_get_v1", "food_sub_categories_get_v1"),
+    ("classification", "sub_categories_get_v2", "food_sub_categories_get_v2"),
+    # Recipes (11)
+    ("recipes", "add_favorite_v1", "recipe_add_favorite_v1"),
+    ("recipes", "delete_favorite_v1", "recipe_delete_favorite_v1"),
+    ("recipes", "get_favorites_v1", "recipes_get_favorites_v1"),
+    ("recipes", "get_favorites_v2", "recipes_get_favorites_v2"),
+    ("recipes", "get_v1", "recipe_get_v1"),
+    ("recipes", "get_v2", "recipe_get_v2"),
+    ("recipes", "search_v1", "recipes_search_v1"),
+    ("recipes", "search_v2", "recipes_search_v2"),
+    ("recipes", "search_v3", "recipes_search_v3"),
+    ("recipes", "types_get_v1", "recipe_types_get_v1"),
+    ("recipes", "types_get_v2", "recipe_types_get_v2"),
+    # Profile Foods (10)
+    ("profile_foods", "add_favorite_v1", "food_add_favorite_v1"),
+    ("profile_foods", "create_v1", "food_create_v1"),
+    ("profile_foods", "create_v2", "food_create_v2"),
+    ("profile_foods", "delete_favorite_v1", "food_delete_favorite_v1"),
+    ("profile_foods", "get_favorites_v1", "foods_get_favorites_v1"),
+    ("profile_foods", "get_favorites_v2", "foods_get_favorites_v2"),
+    ("profile_foods", "get_most_eaten_v1", "foods_get_most_eaten_v1"),
+    ("profile_foods", "get_most_eaten_v2", "foods_get_most_eaten_v2"),
+    ("profile_foods", "get_recently_eaten_v1", "foods_get_recently_eaten_v1"),
+    ("profile_foods", "get_recently_eaten_v2", "foods_get_recently_eaten_v2"),
+    # Meals (10)
+    ("meals", "create_v1", "saved_meal_create_v1"),
+    ("meals", "delete_v1", "saved_meal_delete_v1"),
+    ("meals", "edit_v1", "saved_meal_edit_v1"),
+    ("meals", "get_v1", "saved_meals_get_v1"),
+    ("meals", "get_v2", "saved_meals_get_v2"),
+    ("meals", "item_add_v1", "saved_meal_item_add_v1"),
+    ("meals", "item_delete_v1", "saved_meal_item_delete_v1"),
+    ("meals", "item_edit_v1", "saved_meal_item_edit_v1"),
+    ("meals", "items_get_v1", "saved_meal_items_get_v1"),
+    ("meals", "items_get_v2", "saved_meal_items_get_v2"),
+    # Diary (9)
+    ("diary", "entries_copy_saved_meal_v1", "food_entries_copy_saved_meal_v1"),
+    ("diary", "entries_copy_v1", "food_entries_copy_v1"),
+    ("diary", "entries_get_month_v1", "food_entries_get_month_v1"),
+    ("diary", "entries_get_month_v2", "food_entries_get_month_v2"),
+    ("diary", "entries_get_v1", "food_entries_get_v1"),
+    ("diary", "entries_get_v2", "food_entries_get_v2"),
+    ("diary", "entry_create_v1", "food_entry_create_v1"),
+    ("diary", "entry_delete_v1", "food_entry_delete_v1"),
+    ("diary", "entry_edit_v1", "food_entry_edit_v1"),
+    # Exercises (9)
+    ("exercises", "entries_commit_day_v1", "exercise_entries_commit_day_v1"),
+    ("exercises", "entries_get_month_v1", "exercise_entries_get_month_v1"),
+    ("exercises", "entries_get_month_v2", "exercise_entries_get_month_v2"),
+    ("exercises", "entries_get_v1", "exercise_entries_get_v1"),
+    ("exercises", "entries_get_v2", "exercise_entries_get_v2"),
+    ("exercises", "entries_save_template_v1", "exercise_entries_save_template_v1"),
+    ("exercises", "entry_edit_v1", "exercise_entry_edit_v1"),
+    ("exercises", "list_v1", "exercises_get_v1"),
+    ("exercises", "list_v2", "exercises_get_v2"),
+    # Weight (3)
+    ("weight", "get_month_v1", "weights_get_month_v1"),
+    ("weight", "get_month_v2", "weights_get_month_v2"),
+    ("weight", "update_v1", "weight_update_v1"),
+    # Profile (3)
+    ("profile", "create_v1", "profile_create_v1"),
+    ("profile", "get_auth_v1", "profile_get_auth_v1"),
+    ("profile", "get_v1", "profile_get_v1"),
+    # Native (3)
+    ("native", "image_recognition_v1", "image_recognition_v1"),
+    ("native", "image_recognition_v2", "image_recognition_v2"),
+    ("native", "natural_language_processing_v1", "natural_language_processing_v1"),
+    # Feedback (1)
+    ("feedback", "submit_v1", "feedback_v1"),
+]
+
+
+@pytest.fixture
+def client() -> Fatsecret:
+    return Fatsecret("dummy_key", "dummy_secret")
+
+
+def test_all_resources_attached(client: Fatsecret) -> None:
+    """Every OAS-tag resource is reachable from the client."""
+    expected = {
+        "foods", "classification", "recipes", "profile_foods", "meals",
+        "diary", "exercises", "weight", "profile", "native", "feedback",
+    }
+    for attr in expected:
+        assert hasattr(client, attr), f"missing resource attribute: {attr}"
+
+
+def test_delegation_table_covers_every_resource_method(client: Fatsecret) -> None:
+    """The parametrized table below must cover EVERY public method on EVERY
+    resource. If a new method is added without a parity entry, this fails."""
+    actual = set()
+    for resource_attr in {d[0] for d in DELEGATIONS}:
+        resource = getattr(client, resource_attr)
+        for name in dir(resource):
+            if name.startswith("_"):
+                continue
+            actual.add((resource_attr, name))
+    declared = {(d[0], d[1]) for d in DELEGATIONS}
+    missing_in_table = actual - declared
+    extra_in_table = declared - actual
+    assert not missing_in_table, f"resource methods not in delegation table: {missing_in_table}"
+    assert not extra_in_table, f"delegation table references missing methods: {extra_in_table}"
+
+
+@pytest.mark.parametrize(
+    "resource_attr,ns_method,flat_method",
+    DELEGATIONS,
+    ids=[f"{d[0]}.{d[1]}->{d[2]}" for d in DELEGATIONS],
+)
+def test_namespaced_method_delegates_to_flat(
+    client: Fatsecret,
+    resource_attr: str,
+    ns_method: str,
+    flat_method: str,
+) -> None:
+    """Each namespaced call forwards args/kwargs verbatim to the flat method
+    and returns the flat method's return value."""
+    resource = getattr(client, resource_attr)
+    with patch.object(client, flat_method) as mock_flat:
+        mock_flat.return_value = "sentinel"
+        result = getattr(resource, ns_method)("pos1", "pos2", kw="value")
+    mock_flat.assert_called_once_with("pos1", "pos2", kw="value")
+    assert result == "sentinel"
+
+
+def test_delegation_count_matches_expected_total() -> None:
+    """Locks in the surface size for v2.0 Phase 1: 79 namespaced methods."""
+    assert len(DELEGATIONS) == 79


### PR DESCRIPTION
## What this is

Introduces \`src/fatsecret/resources/\` — 11 resource modules mapping 1:1 to the OAS tags in \`docs/api-spec/openapi.yaml\`. Each resource is attached as an attribute on the client:

\`\`\`python
fs.foods.search_v5(\"toast\")          # was fs.foods_search_v5(...)
fs.diary.entries_get_v2(today)        # was fs.food_entries_get_v2(...)
fs.native.image_recognition_v2(b64)
fs.classification.brands_get_v2()
\`\`\`

## Resources (11 modules, 79 namespaced methods)

| Resource | Methods | OAS tag |
|---|---|---|
| foods | 14 | Foods |
| classification | 6 | Food Classification |
| recipes | 11 | Recipes |
| profile_foods | 10 | Profile Foods |
| meals | 10 | Saved Meals |
| diary | 9 | Food Diary |
| exercises | 9 | Exercise Diary |
| weight | 3 | Weight Diary |
| profile | 3 | Profile Auth |
| native | 3 | Native APIs |
| feedback | 1 | Feedback |

## Phase 1 = ADDITIVE

Each resource method is **pure delegation** to the existing flat \`_vN\` method on \`Fatsecret\`. Zero behavior change. Zero breaking change. Old flat surface continues to work unmodified — every existing user keeps working.

This PR cuts as a **minor** version bump. The major v2.0 bump fires only when the breaking pieces land (Phase 5: drop profile tuple, drop legacy param renames, drop flat methods).

## Test plan

- [x] All 814 existing endpoint coverage tests pass unchanged → flat surface confirmed not broken.
- [x] 82 new parity tests (\`tests/unit/test_resources_phase1.py\`): one per delegation, asserts namespaced call forwards args/kwargs to flat method and returns its result verbatim.
- [x] Three sanity tests: every resource attached, every namespaced method covered by the parity table, total method count == 79.

## v2.0 phase plan (for context)

- [x] Phase 1: resource namespacing (this PR)
- [ ] Phase 1.5: flat methods → DeprecationWarning aliases
- [ ] Phase 2-4: OAS-driven codegen replaces delegation
- [ ] Phase 5: \`feat!:\` major bump for v2.0 — drops tuple returns, legacy param renames, flat methods