### PR TITLE
docs(examples): runnable end-to-end demo using the v2 namespaced surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ release: build  ## Publish to PyPI using uv
 # -----------------------------
 .PHONY: help all example docs docs-serve
 
-example: fmt lint  ## Run the CLI example with API credentials from environment
-	@PYTHONPATH=src uv run python examples/cli_example.py
+example: fmt lint  ## Run the CLI example end-to-end against the live FatSecret API (.env required)
+	@PYTHONPATH=src uv run python examples/main.py
 
 docs:  ## Build Sphinx documentation
 	@rm -rf $(DOCS_DIR)/_build

--- a/examples/cli_example.py
+++ b/examples/cli_example.py
@@ -1,99 +1,12 @@
-import os
-from pprint import pprint
+"""Legacy entry point — kept for back-compat with users who scripted
+`python examples/cli_example.py`. The actual example lives in main.py.
+"""
 
-from dotenv import load_dotenv
+from .main import main  # noqa: F401  (re-export for callers that import this name)
 
-from fatsecret import Fatsecret
-from fatsecret.auth import fatsecret_authenticate
+if __name__ == "__main__":
+    import sys
 
-load_dotenv()
+    from .main import main as _main
 
-consumer_key = os.getenv("FATSECRET_CONSUMER_KEY")
-consumer_secret = os.getenv("FATSECRET_CONSUMER_SECRET")
-username = os.getenv("FATSECRET_USERNAME")
-password = os.getenv("FATSECRET_PASSWORD")
-
-print("Using the following credentials:")
-print(f"  Consumer Key: {consumer_key if consumer_key else '[NOT SET]'}")
-print(f"  Consumer Secret: {consumer_secret if consumer_secret else '[NOT SET]'}")
-
-
-if not consumer_key or not consumer_secret:
-    raise ValueError(
-        "Missing API credentials. Please set FATSECRET_CONSUMER_KEY and "
-        "FATSECRET_CONSUMER_SECRET environment variables."
-    )
-
-# Create unauthenticated client for public API calls
-fs = Fatsecret(consumer_key, consumer_secret)
-
-# Test Calls w/o authentication
-
-print("\n\n ---- No Authentication Required ---- \n\n")
-
-foods = fs.foods_search("Tacos")
-print(f"Food Search Results: {len(foods)}")
-pprint(foods)
-print()
-
-food = fs.food_get("1345")
-print("Food Item 1345")
-pprint(food)
-print()
-
-recipes = fs.recipes_search("Tomato Soup")
-print("Recipe Search Results:")
-pprint(recipes)
-print()
-
-recipe = fs.recipe_get("88339")
-print("Recipe 88339")
-pprint(recipe)
-print()
-
-# Test Calls with 3 Legged Oauth (Automated Authentication)
-
-print("\n\n ------ OAuth Example (Automated) ------ \n\n")
-
-# Automatically authenticate using username/password or saved tokens
-# This function will:
-# 1. Check for FATSECRET_ACCESS_TOKEN and FATSECRET_ACCESS_SECRET env vars first
-# 2. If not found, use FATSECRET_USERNAME and FATSECRET_PASSWORD to automate login
-# 3. Return an authenticated Fatsecret instance or None
-fs_authenticated = fatsecret_authenticate(
-    username=username,
-    password=password,
-    consumer_key=consumer_key,
-    consumer_secret=consumer_secret,
-)
-
-if not fs_authenticated:
-    print("Authentication failed or credentials not provided.")
-    print("Set FATSECRET_USERNAME and FATSECRET_PASSWORD environment variables,")
-    print(
-        "or set FATSECRET_ACCESS_TOKEN and FATSECRET_ACCESS_SECRET to use saved tokens."
-    )
-
-
-print("Successfully authenticated!")
-
-# Get the session token for future reuse
-session_token = (
-    fs_authenticated.access_token,
-    fs_authenticated.access_token_secret,
-)
-print(f"Session Token: {session_token}")
-print(
-    "Save these tokens as FATSECRET_ACCESS_TOKEN and FATSECRET_ACCESS_SECRET for future use!\n"
-)
-
-# Now make authenticated API calls
-
-recipes = fs_authenticated.recipes_search("Enchiladas")
-print(f"Recipe Search Results: {len(recipes)}")
-pprint(recipes)
-print()
-
-profile = fs_authenticated.profile_get()
-print("Profile:")
-pprint(profile)
+    sys.exit(_main())

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,0 +1,162 @@
+"""End-to-end smoke example for the fatsecret wrapper.
+
+Reads credentials from `.env` at the repo root (gitignored). Runs both an
+unauthenticated public-data flow and an authenticated 3-legged OAuth flow
+against the live FatSecret API to confirm the wrapper actually works.
+
+Run with::
+
+    uv run python examples/main.py
+    # or
+    make example
+
+Expected env vars (.env at repo root):
+
+    FATSECRET_CONSUMER_KEY=...        # required
+    FATSECRET_CONSUMER_SECRET=...     # required
+    FATSECRET_USERNAME=...            # optional, enables OAuth section
+    FATSECRET_PASSWORD=...            # optional, enables OAuth section
+    FATSECRET_ACCESS_TOKEN=...        # optional, reuses saved session
+    FATSECRET_ACCESS_SECRET=...       # optional, reuses saved session
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+from pprint import pprint
+from typing import Optional
+
+from dotenv import load_dotenv
+
+from fatsecret import Fatsecret
+
+
+def heading(text: str) -> None:
+    """Render a section divider."""
+    bar = "=" * len(text)
+    print(f"\n{bar}\n{text}\n{bar}")
+
+
+def run_public_demo(fs: Fatsecret) -> None:
+    """Exercise unauthenticated endpoints via the v2 namespaced surface."""
+    heading("Public (unauthenticated) — namespaced surface")
+
+    print("\nfs.foods.search_v1('Tacos') -> first 3 results")
+    foods = fs.foods.search_v1("Tacos")
+    pprint(foods[:3])
+
+    print("\nfs.foods.get_v1(food_id='1345')")
+    food = fs.foods.get_v1(food_id="1345")
+    pprint(food)
+
+    print("\nfs.recipes.search_v1('Tomato Soup') -> first 3 results")
+    recipes = fs.recipes.search_v1("Tomato Soup")
+    pprint(recipes[:3])
+
+    print("\nfs.recipes.get_v1(recipe_id='88339')")
+    recipe = fs.recipes.get_v1(recipe_id="88339")
+    pprint(recipe)
+
+
+def authenticate_from_env(
+    consumer_key: str,
+    consumer_secret: str,
+    username: Optional[str],
+    password: Optional[str],
+    access_token: Optional[str],
+    access_secret: Optional[str],
+) -> Optional[Fatsecret]:
+    """Return an authenticated Fatsecret instance, or None.
+
+    Prefers saved access tokens; falls back to the HTML-form login flow
+    if username/password are present.
+    """
+    if access_token and access_secret:
+        print("\nUsing saved FATSECRET_ACCESS_TOKEN / FATSECRET_ACCESS_SECRET.")
+        return Fatsecret(
+            consumer_key,
+            consumer_secret,
+            session_token=(access_token, access_secret),
+        )
+
+    if username and password:
+        print("\nAuthenticating via FATSECRET_USERNAME / FATSECRET_PASSWORD (HTML scrape).")
+        # `Fatsecret.fatsecret_authenticate` is a helper defined on the class
+        # (no `self`) that drives the 3-legged OAuth flow programmatically.
+        return Fatsecret.fatsecret_authenticate(
+            username, password, consumer_key, consumer_secret
+        )
+
+    return None
+
+
+def run_authenticated_demo(fs_auth: Fatsecret) -> None:
+    """Exercise profile-scoped endpoints via the v2 namespaced surface."""
+    heading("Authenticated (3-legged OAuth) — namespaced surface")
+
+    print("\nfs.recipes.search_v1('Enchiladas') -> first 3 results")
+    recipes = fs_auth.recipes.search_v1("Enchiladas")
+    pprint(recipes[:3])
+
+    print("\nfs.profile.get_v1()")
+    profile = fs_auth.profile.get_v1()
+    pprint(profile)
+
+    print("\nfs.profile_foods.get_most_eaten_v1() — first 3")
+    most_eaten = fs_auth.profile_foods.get_most_eaten_v1()
+    pprint(most_eaten[:3] if isinstance(most_eaten, list) else most_eaten)
+
+    token = (fs_auth.access_token, fs_auth.access_token_secret)
+    print(
+        "\nSave these as FATSECRET_ACCESS_TOKEN / FATSECRET_ACCESS_SECRET to skip\n"
+        f"the HTML-scrape next time:\n  {token}"
+    )
+
+
+def main() -> int:
+    load_dotenv()
+
+    consumer_key = os.getenv("FATSECRET_CONSUMER_KEY")
+    consumer_secret = os.getenv("FATSECRET_CONSUMER_SECRET")
+    username = os.getenv("FATSECRET_USERNAME")
+    password = os.getenv("FATSECRET_PASSWORD")
+    access_token = os.getenv("FATSECRET_ACCESS_TOKEN")
+    access_secret = os.getenv("FATSECRET_ACCESS_SECRET")
+
+    if not consumer_key or not consumer_secret:
+        print(
+            "Missing FATSECRET_CONSUMER_KEY / FATSECRET_CONSUMER_SECRET.\n"
+            "Create a .env at the repo root with at least:\n"
+            "  FATSECRET_CONSUMER_KEY=...\n"
+            "  FATSECRET_CONSUMER_SECRET=...",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Show our own DeprecationWarnings so a maintainer running this gets a
+    # nudge if they accidentally call a flat alias.
+    warnings.filterwarnings("default", category=DeprecationWarning, module="fatsecret")
+
+    fs = Fatsecret(consumer_key, consumer_secret)
+    run_public_demo(fs)
+
+    fs_auth = authenticate_from_env(
+        consumer_key, consumer_secret, username, password, access_token, access_secret
+    )
+    if fs_auth is None:
+        heading("Authenticated demo SKIPPED")
+        print(
+            "No usable credentials.\n"
+            "Set FATSECRET_USERNAME + FATSECRET_PASSWORD or\n"
+            "FATSECRET_ACCESS_TOKEN + FATSECRET_ACCESS_SECRET in .env."
+        )
+        return 0
+
+    run_authenticated_demo(fs_auth)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/web_example.py
+++ b/examples/web_example.py
@@ -15,7 +15,7 @@ fs = Fatsecret(consumer_key, consumer_secret)
 def index():
     if request.args.get("oauth_verifier"):
 
-        session_token = fs.authenticate(request.args.get("oauth_verifier"))
+        fs.authenticate(request.args.get("oauth_verifier"))
 
         return redirect(url_for("profile"))
 


### PR DESCRIPTION
## What this is

Adds \`examples/main.py\` — a runnable smoke demo that exercises both **unauthenticated** (foods/recipes public search + lookup) and **authenticated** (profile read + most-eaten foods) flows against the live FatSecret API, using credentials from a \`.env\` at the repo root.

Surface used throughout: **v2 namespaced** (\`fs.foods.search_v1\`, \`fs.profile.get_v1\`, \`fs.profile_foods.get_most_eaten_v1\`). No flat-method deprecation warnings emitted.

## Other changes

- \`cli_example.py\`: was broken (imported a non-existent \`fatsecret.auth\` module) — turned into a thin shim that re-exports \`main\`.
- \`Makefile\`: \`make example\` now points at the new file.
- \`web_example.py\`: small unused-variable lint fix.

## .env

Already gitignored. Minimum:

\`\`\`
FATSECRET_CONSUMER_KEY=...
FATSECRET_CONSUMER_SECRET=...
\`\`\`

For the authenticated section, add one of:

\`\`\`
FATSECRET_USERNAME=... + FATSECRET_PASSWORD=...
FATSECRET_ACCESS_TOKEN=... + FATSECRET_ACCESS_SECRET=...
\`\`\`

## Test plan

- [x] \`uv run python examples/main.py\` runs end-to-end against the live API: 4 unauth calls + HTML-scrape login + 3 authenticated calls all succeed.
- [x] \`ruff check\` clean.
- [x] 896 unit tests still pass.