### PR TITLE
ci: add OAS regen check to detect drift in generated code

### DIFF
--- a/.github/workflows/oas-regen-check.yml
+++ b/.github/workflows/oas-regen-check.yml
@@ -1,0 +1,71 @@
+name: OAS Regen Check
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  oas-regen-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Cache oas-sync scraper HTML
+        uses: actions/cache@v4
+        with:
+          path: scripts/oas-sync/.cache
+          key: oas-sync-cache-${{ hashFiles('scripts/oas-sync/uv.lock') }}
+          restore-keys: |
+            oas-sync-cache-
+
+      - name: Install oas-sync dependencies
+        working-directory: scripts/oas-sync
+        run: uv sync --frozen
+
+      - name: Snapshot committed pipeline outputs
+        run: |
+          md5sum docs/api-spec/raw/*.yaml docs/api-spec/openapi.yaml \
+            src/fatsecret/resources/_generated/*.py > /tmp/before.md5
+          cat /tmp/before.md5
+
+      - name: Run oas-sync pipeline
+        working-directory: scripts/oas-sync
+        run: |
+          uv run oas-sync sync
+          for tag in "Foods" "Food Classification" "Recipes" "Profile Foods" \
+                     "Saved Meals" "Food Diary" "Exercise Diary" "Weight Diary" \
+                     "Profile Auth" "Native APIs" "Feedback"; do
+              echo "::group::emit-resource $tag"
+              uv run oas-sync emit-resource "$tag"
+              echo "::endgroup::"
+          done
+
+      - name: Snapshot regenerated pipeline outputs
+        run: |
+          md5sum docs/api-spec/raw/*.yaml docs/api-spec/openapi.yaml \
+            src/fatsecret/resources/_generated/*.py > /tmp/after.md5
+          cat /tmp/after.md5
+
+      - name: Diff snapshots
+        id: diff
+        run: diff /tmp/before.md5 /tmp/after.md5
+
+      - name: Show drift on failure
+        if: failure() && steps.diff.outcome == 'failure'
+        run: |
+          echo "::error::Pipeline output diverged from committed files."
+          echo "Re-run the pipeline locally (\`make oas-regen-check\`) and commit the diffs."
+          git --no-pager diff -- \
+            docs/api-spec/raw \
+            docs/api-spec/openapi.yaml \
+            src/fatsecret/resources/_generated || true

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,22 @@ fmt:  ## Auto-format code (black + isort)
 check: lint test  ## Run lint and tests
 
 # -----------------------------
+# OAS pipeline
+# -----------------------------
+.PHONY: oas-regen-check
+
+oas-regen-check:  ## Verify pipeline output matches committed files
+	@md5sum docs/api-spec/raw/*.yaml docs/api-spec/openapi.yaml src/fatsecret/resources/_generated/*.py > /tmp/before.md5
+	@cd scripts/oas-sync && uv run oas-sync sync && \
+	  for tag in "Foods" "Food Classification" "Recipes" "Profile Foods" \
+	             "Saved Meals" "Food Diary" "Exercise Diary" "Weight Diary" \
+	             "Profile Auth" "Native APIs" "Feedback"; do \
+	      uv run oas-sync emit-resource "$$tag"; \
+	  done
+	@md5sum docs/api-spec/raw/*.yaml docs/api-spec/openapi.yaml src/fatsecret/resources/_generated/*.py > /tmp/after.md5
+	@diff /tmp/before.md5 /tmp/after.md5 && echo "✓ pipeline output matches committed files" || (echo "✗ DRIFT — re-run the pipeline locally and commit the diffs"; exit 1)
+
+# -----------------------------
 # Packaging
 # -----------------------------
 .PHONY: build release


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/oas-regen-check.yml` runs on PRs to `master` and pushes to `master`. It snapshots the committed OAS + generated resources, re-runs `oas-sync sync` and `emit-resource` for all 11 tags, then diffs `md5sum` snapshots. Any divergence fails the check and dumps `git diff` of the affected files for an actionable log.
- New Makefile target `make oas-regen-check` runs the same verification locally.
- HTML scraper cache (`scripts/oas-sync/.cache/`) is cached across runs keyed on `scripts/oas-sync/uv.lock` for speed; scraper still runs end-to-end.

## Test plan
- [ ] Open PR; confirm `OAS Regen Check` workflow runs and passes on a clean tree.
- [ ] Locally run `make oas-regen-check` to confirm it succeeds.
- [ ] Manually hand-edit a generated file in a throwaway branch and confirm the workflow fails with a useful diff in logs.