### PR TITLE
feat(ci): add oasdiff semver gate for OAS breaking changes

### DIFF
--- a/.github/workflows/oasdiff.yml
+++ b/.github/workflows/oasdiff.yml
@@ -1,0 +1,124 @@
+name: OAS Semver Gate
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "docs/api-spec/openapi.yaml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  oasdiff:
+    name: oasdiff breaking-change semver gate
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OASDIFF_VERSION: "1.11.7"
+      SPEC_PATH: "docs/api-spec/openapi.yaml"
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          path: head
+          fetch-depth: 1
+
+      - name: Checkout master base
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          path: master
+          fetch-depth: 1
+
+      - name: Install oasdiff
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/oasdiff.tgz \
+            "https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/oasdiff.tgz -C /tmp
+          sudo install -m 0755 /tmp/oasdiff /usr/local/bin/oasdiff
+          oasdiff --version
+
+      - name: Detect any spec diff
+        id: diff
+        run: |
+          set -euo pipefail
+          if diff -q "master/${SPEC_PATH}" "head/${SPEC_PATH}" >/dev/null 2>&1; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+            echo "No OAS diff detected."
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+            echo "OAS spec changed."
+          fi
+
+      - name: Run oasdiff breaking
+        id: breaking
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set +e
+          oasdiff breaking "master/${SPEC_PATH}" "head/${SPEC_PATH}" --fail-on ERR
+          rc=$?
+          set -e
+          echo "exit_code=${rc}" >>"$GITHUB_OUTPUT"
+          if [ "${rc}" -eq 0 ]; then
+            echo "breaking=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "breaking=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Inspect PR for breaking-change signal
+        id: signal
+        if: steps.breaking.outputs.breaking == 'true'
+        run: |
+          set -euo pipefail
+          pr_number="${{ github.event.pull_request.number }}"
+          repo="${{ github.repository }}"
+
+          title=$(gh pr view "${pr_number}" --repo "${repo}" --json title --jq '.title')
+          echo "PR title: ${title}"
+
+          headlines=$(gh pr view "${pr_number}" --repo "${repo}" --json commits --jq '.commits[].messageHeadline')
+          echo "Commit headlines:"
+          echo "${headlines}"
+
+          bodies=$(gh pr view "${pr_number}" --repo "${repo}" --json commits --jq '.commits[].messageBody')
+
+          ok="false"
+
+          # 1. PR title with feat!: prefix
+          if printf '%s' "${title}" | grep -Eq '^feat!:'; then
+            ok="true"
+            echo "Match: PR title uses feat!: prefix."
+          fi
+
+          # 2. Any commit subject with <type>!: prefix (conventional commits)
+          if [ "${ok}" = "false" ] && printf '%s\n' "${headlines}" | grep -Eq '^[a-zA-Z]+(\([^)]*\))?!:'; then
+            ok="true"
+            echo "Match: a commit subject uses <type>!: prefix."
+          fi
+
+          # 3. Any commit body contains BREAKING CHANGE: footer
+          if [ "${ok}" = "false" ] && printf '%s' "${bodies}" | grep -q 'BREAKING CHANGE:'; then
+            ok="true"
+            echo "Match: a commit body contains BREAKING CHANGE: footer."
+          fi
+
+          if [ "${ok}" = "true" ]; then
+            echo "ok=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail when breaking change lacks semver signal
+        if: steps.breaking.outputs.breaking == 'true' && steps.signal.outputs.ok != 'true'
+        run: |
+          echo "::error title=OAS breaking change without semver signal::oasdiff detected a breaking change in ${SPEC_PATH}, but neither the PR title nor any commit subject uses a '<type>!:' prefix and no commit body contains a 'BREAKING CHANGE:' footer. Either rewrite the change to be non-breaking, or mark it as breaking via conventional commits (e.g. 'feat!: ...' or a 'BREAKING CHANGE:' footer)."
+          exit 1
+
+      - name: Warn on non-breaking spec change
+        if: steps.diff.outputs.changed == 'true' && steps.breaking.outputs.breaking == 'false'
+        run: |
+          echo "::warning title=OAS changed::OAS changed; consider whether semver impact is captured."

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ check: lint test  ## Run lint and tests
 # -----------------------------
 # OAS pipeline
 # -----------------------------
-.PHONY: oas-regen-check
+.PHONY: oas-regen-check oasdiff
 
 oas-regen-check:  ## Verify pipeline output matches committed files
 	@md5sum docs/api-spec/raw/*.yaml docs/api-spec/openapi.yaml src/fatsecret/resources/_generated/*.py > /tmp/before.md5
@@ -81,6 +81,9 @@ oas-regen-check:  ## Verify pipeline output matches committed files
 	  done
 	@md5sum docs/api-spec/raw/*.yaml docs/api-spec/openapi.yaml src/fatsecret/resources/_generated/*.py > /tmp/after.md5
 	@diff /tmp/before.md5 /tmp/after.md5 && echo "✓ pipeline output matches committed files" || (echo "✗ DRIFT — re-run the pipeline locally and commit the diffs"; exit 1)
+
+oasdiff:  ## Diff openapi.yaml against origin/master
+	@oasdiff breaking <(git show origin/master:docs/api-spec/openapi.yaml) docs/api-spec/openapi.yaml --fail-on ERR
 
 # -----------------------------
 # Packaging


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/oasdiff.yml` runs on PRs to `master` that touch `docs/api-spec/openapi.yaml`. It checks out PR head + master, installs `oasdiff`, runs `oasdiff breaking ... --fail-on ERR`, and — on a breaking change — requires that the PR signals the break via conventional commits.
- Acceptable signals: PR title with `feat!:` prefix, any commit subject with a `<type>!:` prefix, or any commit body containing `BREAKING CHANGE:`.
- Non-breaking spec changes emit a `::warning::` (no fail). No diff passes silently.
- Adds `make oasdiff` so contributors can reproduce the check locally against `origin/master`.
- Existing `release.yml` conventional-commit detection is unchanged — this is a separate PR-time gate.

## Making this a required check on master
Once this PR has run at least once on `master`, a maintainer can mark the `oasdiff breaking-change semver gate` job as required via:

```bash
gh api -X PATCH repos/${OWNER}/${REPO}/branches/master/protection/required_status_checks \
  -f 'contexts[]=oasdiff breaking-change semver gate'
```

(Or set it via the GitHub UI: Settings -> Branches -> master -> Require status checks.)

## Test plan
- [ ] Workflow YAML parses (validated locally with `python -c "import yaml; yaml.safe_load(open('.github/workflows/oasdiff.yml'))"`).
- [ ] PR that touches `docs/api-spec/openapi.yaml` with a non-breaking change shows the warning and passes.
- [ ] PR that introduces a breaking OAS change with `feat:` (no `!`) and no `BREAKING CHANGE:` footer fails the gate.
- [ ] Same breaking PR retitled `feat!: ...` (or with `BREAKING CHANGE:` footer added to a commit) passes the gate.
- [ ] PR that does not touch the spec is skipped entirely (paths filter).
- [ ] `make oasdiff` runs locally and exits non-zero on a breaking change vs `origin/master`.