### PR TITLE
chore(examples): mask access token tuple in main.py output

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -108,10 +108,14 @@ def run_authenticated_demo(fs_auth: Fatsecret) -> None:
     most_eaten = fs_auth.profile_foods.get_most_eaten_v1()
     pprint(most_eaten[:3] if isinstance(most_eaten, list) else most_eaten)
 
-    token = (fs_auth.access_token, fs_auth.access_token_secret)
+    def _tail(s: str) -> str:
+        return f"****{s[-4:]}" if s and len(s) > 4 else "****"
+
+    masked = (_tail(fs_auth.access_token), _tail(fs_auth.access_token_secret))
     print(
         "\nSave these as FATSECRET_ACCESS_TOKEN / FATSECRET_ACCESS_SECRET to skip\n"
-        f"the HTML-scrape next time:\n  {token}"
+        f"the HTML-scrape next time (printed masked, look in fs_auth.access_token /\n"
+        f"fs_auth.access_token_secret for the full values):\n  {masked}"
     )
 
 


### PR DESCRIPTION
Print last 4 chars only (`****abcd`) instead of the full secret pair. Full values are still on `fs_auth.access_token` / `fs_auth.access_token_secret` for callers that need them.

Hygiene fix — `make example` output was previously copy-pasteable as a working credential pair.