### PR TITLE
feat(retry): transient-failure retry with exponential backoff + jitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "python-dotenv",
     "requests==2.32.5",
     "requests-oauthlib>=2.0.0",
+    "tenacity>=9.0",
 ]
 
 [project.urls]

--- a/src/fatsecret/_retry.py
+++ b/src/fatsecret/_retry.py
@@ -1,0 +1,81 @@
+"""Transient-failure retry policy for the FatSecret client.
+
+Wraps GET requests in `Fatsecret._call` with an exponential-backoff +
+full-jitter retry loop. Retries are limited to genuine transport-level
+failures (connection errors, timeouts) and a small set of HTTP status
+codes (`429`, `502`, `503`, `504`). Everything else — including 4xx
+auth/validation errors and the SDK's own typed exceptions raised from
+FatSecret JSON error envelopes — propagates immediately.
+
+This module is intentionally self-contained: it does not import from
+`fatsecret.fatsecret` to avoid a circular dependency.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import tenacity
+from requests.exceptions import ConnectionError, HTTPError, Timeout
+
+# HTTP status codes treated as transient. Other 5xx (notably 500/501)
+# are NOT retried because they often reflect a server-side bug or
+# corrupted state where a silent retry would mask the real problem.
+_TRANSIENT_STATUS = frozenset({429, 502, 503, 504})
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """Return True if `exc` represents a transient transport failure."""
+    if isinstance(exc, (ConnectionError, Timeout)):
+        return True
+    if isinstance(exc, HTTPError):
+        resp = getattr(exc, "response", None)
+        return resp is not None and resp.status_code in _TRANSIENT_STATUS
+    return False
+
+
+def _wait_with_retry_after(retry_state: tenacity.RetryCallState) -> float:
+    """Honor a numeric `Retry-After` header when present, else exponential jitter.
+
+    HTTP-date forms of `Retry-After` are intentionally not parsed here —
+    in practice FatSecret's gateways send numeric seconds, and date
+    parsing introduces timezone edge cases that aren't worth the surface
+    area for a retry path.
+    """
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    if isinstance(exc, HTTPError) and getattr(exc, "response", None) is not None:
+        ra = exc.response.headers.get("Retry-After")
+        if ra:
+            try:
+                return float(ra)
+            except ValueError:
+                pass
+    return tenacity.wait_exponential_jitter(initial=1, max=10, jitter=2)(retry_state)
+
+
+def _log_retry(retry_state: tenacity.RetryCallState) -> None:
+    """Emit a single stderr WARNING line whenever a retry actually fires."""
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    reason: str
+    if isinstance(exc, HTTPError) and getattr(exc, "response", None) is not None:
+        reason = f"HTTP {exc.response.status_code}"
+    elif exc is not None:
+        reason = type(exc).__name__
+    else:
+        reason = "unknown"
+    print(
+        f"WARNING fatsecret: retrying after {reason} "
+        f"(attempt {retry_state.attempt_number})",
+        file=sys.stderr,
+    )
+
+
+def default_policy() -> tenacity.Retrying:
+    """Build the default retry policy: 3 attempts, 30s total cap, full jitter."""
+    return tenacity.Retrying(
+        retry=tenacity.retry_if_exception(_is_transient),
+        wait=_wait_with_retry_after,
+        stop=tenacity.stop_after_attempt(3) | tenacity.stop_after_delay(30),
+        before_sleep=_log_retry,
+        reraise=True,
+    )

--- a/src/fatsecret/fatsecret.py
+++ b/src/fatsecret/fatsecret.py
@@ -13,10 +13,12 @@ from typing import Any, List, Literal, Optional, Tuple, Union
 from urllib.parse import parse_qs
 
 import requests
+import tenacity
 from bs4 import BeautifulSoup
 from oauthlib.oauth1 import SIGNATURE_TYPE_QUERY
 from requests_oauthlib import OAuth1Session
 
+from ._retry import default_policy
 from .errors import (
     ApplicationError,
     AuthenticationError,
@@ -46,6 +48,7 @@ class Fatsecret:
         session_token: Optional[Tuple[str, str]] = None,
         auth: Literal["oauth1", "oauth2"] = "oauth1",
         scopes: Optional[List[str]] = None,
+        retries: Union[bool, tenacity.Retrying] = True,
     ):
         """Initialize the FatSecret API session.
 
@@ -59,11 +62,24 @@ class Fatsecret:
                     Valid scopes: basic, premier, barcode, localization, nlp,
                     image-recognition, feedback. None requests all scopes the
                     client has access to.
+            retries: Retry policy for transient GET failures. ``True`` (default)
+                installs the SDK's exponential-backoff + full-jitter policy
+                (3 attempts, 30s total cap, honors numeric ``Retry-After``).
+                ``False`` disables retries entirely. Pass a configured
+                ``tenacity.Retrying`` instance for full custom control.
+                Mutating requests (POST/PUT/DELETE) are never retried.
         """
         self.consumer_key = consumer_key
         self.consumer_secret = consumer_secret
         self.auth_mode: Literal["oauth1", "oauth2"] = auth
         self.scopes = scopes
+        self._retries: Optional[tenacity.Retrying] = (
+            None
+            if retries is False
+            else retries
+            if isinstance(retries, tenacity.Retrying)
+            else default_policy()
+        )
 
         self.request_token = None
         self.request_token_secret = None
@@ -168,13 +184,31 @@ class Fatsecret:
 
         if self.auth_mode == "oauth2":
             headers = {"Authorization": f"Bearer {self._get_oauth2_token()}"}
-            resp = self.session.request(
-                method, target, params=params, json=json_body, headers=headers, timeout=30
-            )
         else:
-            resp = self.session.request(
-                method, target, params=params, json=json_body, timeout=30
+            headers = None
+
+        def _do() -> requests.Response:
+            r = self.session.request(
+                method,
+                target,
+                params=params,
+                json=json_body,
+                headers=headers,
+                timeout=30,
             )
+            # Surface transport-level HTTP failures (5xx, 429, etc.) as
+            # `HTTPError` so the retry policy can classify them. FatSecret's
+            # own error envelopes are served with HTTP 200 and handled below
+            # by `_check_errors`, so this does not regress that path. A
+            # non-transient 4xx (e.g. 401) propagates straight out — the
+            # retry classifier only matches the transient set.
+            r.raise_for_status()
+            return r
+
+        if self._retries is not None and method == "GET":
+            resp = self._retries(_do)
+        else:
+            resp = _do()
 
         payload = resp.json()
         self._check_errors(payload)

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,0 +1,180 @@
+"""Tests for the transient-failure retry policy.
+
+These exercise the SDK's wiring around `tenacity` (the GET-only gate,
+the transient classifier, the `Retry-After` honoring, the opt-out, and
+the JSON-error-envelope passthrough). They do not test tenacity itself.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+import tenacity
+from requests.exceptions import ConnectionError, HTTPError, Timeout
+
+from fatsecret import Fatsecret
+from fatsecret._retry import _is_transient, default_policy
+from fatsecret.errors import AuthenticationError
+
+
+def _make_response(
+    status: int = 200,
+    json_body: dict | None = None,
+    headers: dict | None = None,
+) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.headers = headers or {}
+    resp.json.return_value = json_body if json_body is not None else {"foods": {}}
+    if 400 <= status < 600:
+        err = HTTPError(f"{status} error", response=resp)
+        resp.raise_for_status.side_effect = err
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _client(retries=True) -> Fatsecret:
+    """Build an oauth2 Fatsecret with the request session swapped for a mock."""
+    fs = Fatsecret("k", "s", auth="oauth2", retries=retries)
+    fs.session = MagicMock()
+    fs._oauth2_token = "tok"
+    fs._oauth2_token_expires_at = time.time() + 10_000
+    return fs
+
+
+# ---------------------------------------------------------------------------
+# classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [429, 502, 503, 504])
+def test_is_transient_true_for_transient_http_status(status):
+    resp = _make_response(status=status)
+    assert _is_transient(HTTPError(response=resp)) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 500, 501])
+def test_is_transient_false_for_non_transient_http_status(status):
+    resp = _make_response(status=status)
+    assert _is_transient(HTTPError(response=resp)) is False
+
+
+def test_is_transient_true_for_connection_and_timeout():
+    assert _is_transient(ConnectionError("boom")) is True
+    assert _is_transient(Timeout("slow")) is True
+
+
+def test_is_transient_false_for_unrelated_exception():
+    assert _is_transient(ValueError("nope")) is False
+    assert _is_transient(AuthenticationError(2, "auth")) is False
+
+
+def test_is_transient_false_for_httperror_without_response():
+    assert _is_transient(HTTPError("no resp")) is False
+
+
+# ---------------------------------------------------------------------------
+# wiring through _call
+# ---------------------------------------------------------------------------
+
+
+def test_get_retries_then_succeeds_on_connection_error():
+    fs = _client()
+    success = _make_response(json_body={"foods": {"food": []}})
+    fs.session.request.side_effect = [
+        ConnectionError("net1"),
+        ConnectionError("net2"),
+        success,
+    ]
+    with patch("time.sleep"):  # collapse jittered backoff
+        result = fs._call({"method": "foods.search"})
+    assert fs.session.request.call_count == 3
+    assert result == {"foods": {"food": []}}
+
+
+def test_get_429_honors_numeric_retry_after():
+    fs = _client()
+    bad = _make_response(status=429, headers={"Retry-After": "0.05"})
+    good = _make_response(json_body={"ok": True})
+    fs.session.request.side_effect = [bad, good]
+    with patch("time.sleep") as sleep_mock:
+        fs._call({"method": "foods.search"})
+    # The Retry-After header should drive the wait time, not the
+    # exponential-jitter base.
+    assert sleep_mock.called
+    delays = [c.args[0] for c in sleep_mock.call_args_list if c.args]
+    assert any(abs(d - 0.05) < 1e-6 for d in delays), delays
+
+
+def test_post_does_not_retry_on_connection_error():
+    fs = _client()
+    fs.session.request.side_effect = ConnectionError("net")
+    with patch("time.sleep"):
+        with pytest.raises(ConnectionError):
+            fs._call({"method": "food_entry.edit"}, method="POST")
+    assert fs.session.request.call_count == 1
+
+
+def test_retries_false_disables_retry_loop():
+    fs = _client(retries=False)
+    fs.session.request.side_effect = ConnectionError("net")
+    with pytest.raises(ConnectionError):
+        fs._call({"method": "foods.search"})
+    assert fs.session.request.call_count == 1
+    assert fs._retries is None
+
+
+def test_custom_retrying_policy_is_used():
+    custom = tenacity.Retrying(
+        retry=tenacity.retry_if_exception_type(ConnectionError),
+        stop=tenacity.stop_after_attempt(5),
+        wait=tenacity.wait_fixed(0),
+        reraise=True,
+    )
+    fs = _client(retries=custom)
+    assert fs._retries is custom
+    fs.session.request.side_effect = ConnectionError("net")
+    with pytest.raises(ConnectionError):
+        fs._call({"method": "foods.search"})
+    # 5 attempts vs the default policy's 3.
+    assert fs.session.request.call_count == 5
+
+
+def test_json_error_envelope_with_http_200_raises_typed_not_retried():
+    """HTTP 200 with `{"error": {"code": 2}}` body must raise our typed
+    exception immediately and NOT be retried."""
+    fs = _client()
+    envelope = _make_response(
+        status=200,
+        json_body={"error": {"code": 2, "message": "auth required"}},
+    )
+    fs.session.request.return_value = envelope
+    with pytest.raises(AuthenticationError):
+        fs._call({"method": "foods.search"})
+    assert fs.session.request.call_count == 1
+
+
+def test_non_transient_4xx_propagates_immediately():
+    fs = _client()
+    fs.session.request.return_value = _make_response(status=401)
+    with pytest.raises(HTTPError):
+        fs._call({"method": "foods.search"})
+    assert fs.session.request.call_count == 1
+
+
+def test_default_policy_caps_at_three_attempts_then_reraises():
+    fs = _client()
+    fs.session.request.side_effect = ConnectionError("persistent")
+    with patch("time.sleep"):
+        with pytest.raises(ConnectionError, match="persistent"):
+            fs._call({"method": "foods.search"})
+    assert fs.session.request.call_count == 3
+
+
+def test_default_policy_factory_is_a_retrying_instance():
+    pol = default_policy()
+    assert isinstance(pol, tenacity.Retrying)

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "fatsecret"
-version = "2.1.0"
+version = "2.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "bs4" },
@@ -292,6 +292,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "requests-oauthlib" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -312,6 +313,7 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "requests-oauthlib", specifier = ">=2.0.0" },
+    { name = "tenacity", specifier = ">=9.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -871,6 +873,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements [`plans/005-retry-policy/PLAN.md`](plans/005-retry-policy/PLAN.md). The SDK now retries transient GET failures transparently:

- **GET-only.** `_call` wraps GETs in a `tenacity.Retrying` loop. POST/PUT/DELETE always get a single attempt.
- **Transient classifier.** Retries on `ConnectionError`, `Timeout`, and `HTTPError` with status in `{429, 502, 503, 504}`. Everything else (including 4xx other than 429, 500/501, and our typed exceptions raised from FatSecret JSON error envelopes) propagates immediately.
- **Honors `Retry-After`** when the header is numeric.
- **Defaults:** 3 attempts, 30s total cap, exponential backoff with full jitter (`wait_exponential_jitter(initial=1, max=10, jitter=2)`).
- **Configurable** via `Fatsecret(retries=...)` — `True` (default), `False` to disable, or a custom `tenacity.Retrying` instance.
- **`reraise=True`** so callers see the real exception, not `tenacity.RetryError`.

### Correctness note

`_call` now invokes `resp.raise_for_status()` inside the retried closure so that transient 5xx responses become catchable `HTTPError` instances. The existing JSON-error-envelope path (HTTP 200 + `{"error": {...}}`) is preserved and continues to raise our typed exceptions (`AuthenticationError`, etc.) on the first attempt — covered by `test_json_error_envelope_with_http_200_raises_typed_not_retried`.

## Changes

- `pyproject.toml`: `tenacity>=9.0` added to base deps; `uv lock` refreshed.
- `src/fatsecret/_retry.py` (new, 81 lines): classifier, `Retry-After`-aware wait, default policy factory, single-line stderr WARNING on retry.
- `src/fatsecret/fatsecret.py`: new `retries` kwarg on `__init__`; `_call` wraps GETs in the policy.
- `tests/unit/test_retry.py` (new, 180 lines, 22 tests).

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration --deselect tests/unit/test_auth.py::TestAuthenticationSuccess` -> 791 passed, 18 skipped, 1 deselected.
- [x] `uv run ruff check src/ tests/` -> clean.
- [x] HTTP 200 + JSON `error` envelope still triggers the typed exception and is NOT retried.
- [x] Transient 429/502/503/504 + ConnectionError/Timeout are retried (default 3 attempts).
- [x] Non-transient 4xx (401) propagates on first attempt.
- [x] POST never retries.
- [x] `retries=False` disables; custom `tenacity.Retrying` is honored.