### PR TITLE
docs: add "v3 in development" banner to dev builds

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,11 @@
+{% extends "!layout.html" %}
+{% block document %}
+{% if is_dev_build %}
+<div class="admonition warning" style="margin-bottom: 1em;">
+  <p class="admonition-title">v3 in development</p>
+  <p>You're viewing in-development documentation. For the released stable docs, see
+  <a href="https://fatsecret.readthedocs.io/en/stable/">fatsecret.readthedocs.io/en/stable/</a>.</p>
+</div>
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 from pathlib import Path
@@ -18,5 +19,11 @@ extensions = [
 
 exclude_patterns = ["_build"]
 add_module_names = False
+templates_path = ["_templates"]
 
 html_theme = "sphinx_rtd_theme"
+
+# Show an in-development banner only on Read the Docs branch builds
+# (e.g., master/dev). Tagged version builds set VERSION_TYPE=tag and stay clean.
+_is_dev_build = os.environ.get("READTHEDOCS_VERSION_TYPE") == "branch"
+html_context = {"is_dev_build": _is_dev_build}


### PR DESCRIPTION
## Summary

Adds a small admonition banner above the document content on Read the Docs **branch** builds (e.g., master/dev), pointing readers to the stable docs URL. Tagged version builds stay clean.

## How it works

Read the Docs sets the env var \`READTHEDOCS_VERSION_TYPE\` for every build:

- \`branch\` — non-tagged refs (master, dev) → banner shown
- \`tag\` — tagged version builds (v2.3.3, v3.0.0, etc.) → banner NOT shown
- \`external\` / \`unknown\` → banner NOT shown

\`docs/conf.py\` reads the env var and exposes a boolean \`is_dev_build\` via \`html_context\`. \`docs/_templates/layout.html\` overrides the \`sphinx_rtd_theme\` \`{% block document %}\` and renders the banner when the flag is true.

## Why now

Once v3.0.0 tags eventually trigger an RTD build, \`fatsecret.readthedocs.io/en/latest/\` will start showing v3 docs. Visitors landing there while v3 is still in development should see a clear pointer to the stable v2 docs. This PR is independent of v3 work and ships into v2.

## Files changed

- \`docs/conf.py\` — read \`READTHEDOCS_VERSION_TYPE\`, set \`templates_path\` and \`html_context\`
- \`docs/_templates/layout.html\` — new; extends \`!layout.html\`, conditional banner in \`{% block document %}\`

## Test plan

- [x] \`READTHEDOCS_VERSION_TYPE=branch uv run sphinx-build -b html -W docs docs/_build/html\` — banner appears on index/api/usage pages
- [x] \`uv run sphinx-build -b html -W docs docs/_build/html\` (no env var) — banner absent from all pages
- [ ] After merge: confirm RTD master build shows banner, tagged v2.3.x builds do not