### PR TITLE
docs: group API methods by OpenAPI tag

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
       # instead of uv's separate `.venv`. Without this, sphinx-rtd-theme
       # goes to the wrong env and the build fails with
       # `ThemeError: no theme named 'sphinx_rtd_theme' found`.
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --frozen
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --all-groups --frozen
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: true

--- a/docs/_ext/fatsecret_oas.py
+++ b/docs/_ext/fatsecret_oas.py
@@ -1,0 +1,298 @@
+"""Sphinx extension: group ``fatsecret.Fatsecret`` API methods by OpenAPI tag.
+
+Reads ``docs/api-spec/openapi.generated.yaml`` at build time, maps each OAS
+operationId to its concrete Python method (resource sub-objects on a
+``Fatsecret`` instance, e.g. ``Fatsecret.foods.search_v5``), and emits one
+section per tag. Falls back to a flat ``autoclass`` block if the spec or
+pyyaml is missing so older tags / minimal checkouts still build.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import StringList
+
+# OAS tag -> ordered list of Python resource attribute names to search.
+# First match wins. Covers every tag in openapi.generated.yaml as of 2026-05.
+_TAG_TO_RESOURCES: dict[str, list[str]] = {
+    "food": ["foods", "profile_foods"],
+    "foods": ["foods", "profile_foods"],
+    "food_brands": ["classification"],
+    "food_categories": ["classification"],
+    "food_sub_categories": ["classification"],
+    "food_entries": ["diary"],
+    "food_entry": ["diary"],
+    "exercises": ["exercises"],
+    "exercise_entries": ["exercises"],
+    "exercise_entry": ["exercises"],
+    "recipe": ["recipes"],
+    "recipes": ["recipes"],
+    "recipe_types": ["recipes"],
+    "saved_meal": ["meals"],
+    "saved_meals": ["meals"],
+    "saved_meal_item": ["meals"],
+    "saved_meal_items": ["meals"],
+    "weight": ["weight"],
+    "weights": ["weight"],
+    "image": ["native"],
+    "natural": ["native"],
+    "profile": ["profile", "profile_foods"],
+    "feedback": ["feedback"],
+}
+
+_TAG_HEADING: dict[str, str] = {
+    "food": "Food",
+    "foods": "Foods (search, autocomplete, favorites)",
+    "food_brands": "Food Brands",
+    "food_categories": "Food Categories",
+    "food_sub_categories": "Food Sub-Categories",
+    "food_entries": "Food Diary Entries",
+    "food_entry": "Food Diary Entry",
+    "exercises": "Exercises",
+    "exercise_entries": "Exercise Diary Entries",
+    "exercise_entry": "Exercise Diary Entry",
+    "recipe": "Recipe",
+    "recipes": "Recipes",
+    "recipe_types": "Recipe Types",
+    "saved_meal": "Saved Meal",
+    "saved_meals": "Saved Meals",
+    "saved_meal_item": "Saved Meal Item",
+    "saved_meal_items": "Saved Meal Items",
+    "weight": "Weight",
+    "weights": "Weights (history)",
+    "image": "Image Recognition",
+    "natural": "Natural Language Processing",
+    "profile": "Profile",
+    "feedback": "Feedback",
+}
+
+# Explicit overrides where the operationId does not derive from any
+# (resource, method) substring (renamed for clarity in the Python surface).
+_OP_OVERRIDES: dict[str, tuple[str, str]] = {
+    "exercises_get_v1": ("exercises", "list_v1"),
+    "exercises_get_v2": ("exercises", "list_v2"),
+    "feedback_v1": ("feedback", "submit_v1"),
+}
+
+
+_log = logging.getLogger(__name__)
+
+
+def _load_spec(path: Path) -> Optional[dict]:
+    if not path.is_file():
+        return None
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        _log.warning("fatsecret_oas: pyyaml not installed; falling back to flat autoclass")
+        return None
+    try:
+        with path.open() as f:
+            return yaml.safe_load(f)
+    except Exception as exc:
+        _log.warning("fatsecret_oas: failed to parse %s: %s", path, exc)
+        return None
+
+
+def _collect_ops(spec: dict) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = defaultdict(list)
+    for _path, pathitem in (spec.get("paths") or {}).items():
+        if not isinstance(pathitem, dict):
+            continue
+        for _method, op in pathitem.items():
+            if not isinstance(op, dict) or "operationId" not in op:
+                continue
+            primary = op.get("tags") or ["Untagged"]
+            for tag in primary:
+                groups[tag].append(op["operationId"])
+            for sub in op.get("x-fatsecret-additional-operations") or []:
+                if not isinstance(sub, dict) or "operationId" not in sub:
+                    continue
+                for tag in sub.get("tags") or primary:
+                    groups[tag].append(sub["operationId"])
+    return groups
+
+
+def _resource_inventory(cls) -> tuple[dict[str, set[str]], dict[str, type]]:
+    """Return ``({attr: {method, ...}}, {attr: ResourceClass})``."""
+    try:
+        fs = cls("_docs_consumer_key", "_docs_consumer_secret")
+    except Exception:
+        return {}, {}
+    try:
+        from fatsecret.resources._base import BaseResource  # type: ignore
+    except Exception:
+        BaseResource = None  # type: ignore
+    methods: dict[str, set[str]] = {}
+    classes: dict[str, type] = {}
+    for name in dir(fs):
+        if name.startswith("_"):
+            continue
+        try:
+            val = getattr(fs, name)
+        except Exception:
+            continue
+        if BaseResource is not None and not isinstance(val, BaseResource):
+            continue
+        if BaseResource is None and not hasattr(val, "_client"):
+            continue
+        methods[name] = {
+            m for m in dir(val)
+            if not m.startswith("_") and callable(getattr(val, m, None))
+        }
+        classes[name] = type(val)
+    return methods, classes
+
+
+def _candidate_method_names(op_id: str, tag: str) -> list[str]:
+    """Generate plausible Python method names for ``op_id`` under ``tag``.
+
+    OAS operationIds tend to be ``<tag>_<method>`` but the Python resource
+    name does not always equal the tag (e.g. tag ``food_brands`` maps to
+    ``classification.brands_get_v1``). So we yield several stripped forms:
+    the verbatim id, the tag-stripped id, and every progressively shorter
+    underscore-prefix removal.
+    """
+    parts = op_id.split("_")
+    cands: set[str] = {op_id}
+    if op_id.startswith(tag + "_"):
+        cands.add(op_id[len(tag) + 1 :])
+    for i in range(1, len(parts)):
+        cand = "_".join(parts[i:])
+        if cand:
+            cands.add(cand)
+    # Prefer longest candidates first so that, e.g., `types_get_v1` wins
+    # over `get_v1` when both nominally exist on the same resource.
+    return sorted(cands, key=lambda c: (-len(c), c))
+
+
+def _resolve(
+    op_id: str,
+    tag: str,
+    methods: dict[str, set[str]],
+    classes: dict[str, type],
+) -> Optional[tuple[str, str, str]]:
+    """Return ``(resource_attr, method_name, dotted_class_target)`` or None."""
+    if op_id in _OP_OVERRIDES:
+        res, name = _OP_OVERRIDES[op_id]
+        cls = classes.get(res)
+        if cls is not None and name in methods.get(res, set()):
+            return res, name, f"{cls.__module__}.{cls.__qualname__}.{name}"
+    candidates = _TAG_TO_RESOURCES.get(tag, list(methods.keys()))
+    for res in candidates:
+        cls = classes.get(res)
+        if cls is None:
+            continue
+        for name in _candidate_method_names(op_id, tag):
+            if name in methods[res]:
+                return res, name, f"{cls.__module__}.{cls.__qualname__}.{name}"
+    return None
+
+
+class FatsecretApiGroupsDirective(Directive):
+    has_content = False
+    required_arguments = 0
+    optional_arguments = 0
+
+    def run(self):
+        env = self.state.document.settings.env
+        spec = _load_spec(Path(env.srcdir) / "api-spec" / "openapi.generated.yaml")
+        try:
+            from fatsecret import Fatsecret  # type: ignore
+        except Exception:
+            return self._fallback()
+        if spec is None:
+            return self._fallback()
+
+        methods, classes = _resource_inventory(Fatsecret)
+        groups = _collect_ops(spec)
+
+        tag_order = sorted(groups.keys())
+        if "Authentication" in tag_order:
+            tag_order.remove("Authentication")
+            tag_order.insert(0, "Authentication")
+
+        lines: list[str] = []
+        unresolved: list[str] = []
+        seen: set[str] = set()
+
+        for tag in tag_order:
+            heading = _TAG_HEADING.get(tag, tag)
+            lines.append(heading)
+            lines.append("-" * len(heading))
+            lines.append("")
+            for op_id in sorted(set(groups[tag])):
+                resolved = _resolve(op_id, tag, methods, classes)
+                if resolved is None:
+                    unresolved.append(f"{tag}:{op_id}")
+                    lines.append(f"* ``{op_id}`` (no matching Python method)")
+                    lines.append("")
+                    continue
+                attr, mname, target = resolved
+                accessor = f"Fatsecret.{attr}.{mname}()"
+                if target in seen:
+                    lines.append(f"* ``{accessor}`` -- also tagged ``{tag}``.")
+                    lines.append("")
+                    continue
+                seen.add(target)
+                lines.append(f"**{accessor}**")
+                lines.append("")
+                lines.append(f".. automethod:: {target}")
+                lines.append("")
+
+        try:
+            util = sorted(
+                m for m in dir(Fatsecret)
+                if not m.startswith("_")
+                and callable(getattr(Fatsecret, m, None))
+                and m not in methods
+            )
+        except Exception:
+            util = []
+        util_heading = "Client utilities"
+        lines.append(util_heading)
+        lines.append("-" * len(util_heading))
+        lines.append("")
+        for m in util:
+            lines.append(f".. automethod:: fatsecret.Fatsecret.{m}")
+            lines.append("")
+
+        if unresolved:
+            _log.info(
+                "fatsecret_oas: %d operations had no Python match: %s%s",
+                len(unresolved),
+                ", ".join(unresolved[:5]),
+                "..." if len(unresolved) > 5 else "",
+            )
+
+        rst = StringList(lines, source="<fatsecret_oas>")
+        node = nodes.section()
+        node.document = self.state.document
+        self.state.nested_parse(rst, 0, node, match_titles=True)
+        return node.children
+
+    def _fallback(self):
+        rst = StringList(
+            [
+                ".. autoclass:: fatsecret.Fatsecret",
+                "   :members:",
+                "   :noindex:",
+                "   :exclude-members: __init__",
+            ],
+            source="<fatsecret_oas-fallback>",
+        )
+        node = nodes.section()
+        node.document = self.state.document
+        self.state.nested_parse(rst, 0, node, match_titles=True)
+        return node.children
+
+
+def setup(app):
+    app.add_directive("fatsecret-api-groups", FatsecretApiGroupsDirective)
+    return {"version": "1.0", "parallel_read_safe": True}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,7 +10,11 @@ warnings during development, run Python with::
 
     python -W default::DeprecationWarning:fatsecret
 
-.. autoclass:: fatsecret.Fatsecret
-    :members:
-    :noindex:
-    :exclude-members: __init__
+The endpoint methods below are exposed via resource sub-objects on a
+:class:`fatsecret.Fatsecret` instance -- e.g. ``fs.foods.search_v5(...)`` --
+and are grouped by their OpenAPI tag (sourced from
+``docs/api-spec/openapi.generated.yaml``). Client-only helpers (auth
+handshake, session lifecycle, time conversion) are listed at the bottom
+under **Client utilities**.
+
+.. fatsecret-api-groups::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 _root = Path(__file__).parent.parent
 sys.path.insert(0, str(_root / "src"))
+sys.path.insert(0, str(_root / "docs" / "_ext"))
+sys.path.insert(0, str(_root / "docs" / "_ext"))
 
 project = "fatsecret"
 copyright = "2026"
@@ -14,6 +16,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.viewcode",
+    "fatsecret_oas",
 ]
 
 exclude_patterns = ["_build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,5 @@ dev = [
     "ruff",
     "sphinx-rtd-theme>=3.0.2",
     "sphinx>=7.4.7",
+    "pyyaml>=6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "fatsecret"
-version = "2.3.0"
+version = "2.3.3"
 source = { virtual = "." }
 dependencies = [
     { name = "bs4" },
@@ -305,6 +305,7 @@ dev = [
     { name = "isort" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
@@ -326,6 +327,7 @@ dev = [
     { name = "isort" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff" },
     { name = "sphinx", specifier = ">=7.4.7" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
@@ -689,6 +691,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
     { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New Sphinx extension `docs/_ext/fatsecret_oas.py` reads `docs/api-spec/openapi.generated.yaml` and groups documented methods by OAS tag instead of a flat alphabetical dump.
- 23 tag-based sections cover all 79 OAS operations (73 unique Python methods; some are cross-tagged), plus a final **Client utilities** section for non-API helpers (`authenticate`, `close`, `get_authorize_url`, `fatsecret_authenticate`, `unix_time`, `unix_time_v2`, `valid_response`).
- The extension degrades gracefully (falls back to `autoclass :members:`) when either the YAML spec or `pyyaml` is missing, so older tags without `openapi.generated.yaml` keep building.
- Adds `pyyaml>=6.0` to the dev dependency group and bumps the RTD `uv sync` invocation to `--all-groups` so it lands in the docs build venv.

## Test plan

- [x] `sphinx-build -W docs docs/_build/html` succeeds locally with no warnings.
- [x] Generated `api.html` shows one `<h2>` per OAS tag plus a Client utilities section.
- [x] All 79 OAS operations resolve to a concrete Python method (verified by introspection).
- [ ] RTD build of this branch is green before merge.