### PR TITLE
fix(tests): integration tests use attribute access for v3 typed models

### DIFF
--- a/tests/integration/test_foods_integration.py
+++ b/tests/integration/test_foods_integration.py
@@ -7,10 +7,10 @@ def test_food_get_basic(fatsecret_client):
     food_id = "4380"
     result = fatsecret_client.foods.get_v1(food_id=food_id)
 
-    assert isinstance(result, dict)
-    assert result["food_id"] == food_id
-    assert "food_name" in result
-    assert "servings" in result
+    assert result is not None
+    assert str(result.food_id) == food_id
+    assert result.food_name is not None
+    assert result.servings is not None
 
 
 @pytest.mark.integration
@@ -18,7 +18,7 @@ def test_foods_search_basic(fatsecret_client):
     """Ensure searching returns a list of foods."""
     results = fatsecret_client.foods.search_v1("banana")
     assert isinstance(results, list)
-    assert any("banana" in f["food_name"].lower() for f in results)
+    assert any("banana" in f.food_name.lower() for f in results)
 
 
 @pytest.mark.integration
@@ -26,10 +26,10 @@ def test_food_get_v2_basic(fatsecret_client):
     """Fetch a known food using v2 and verify essential fields."""
     food_id = "4380"
     result = fatsecret_client.foods.get_v2(food_id=food_id)
-    assert isinstance(result, dict)
-    assert result["food_id"] == food_id
-    assert "food_name" in result
-    assert "servings" in result
+    assert result is not None
+    assert str(result.food_id) == food_id
+    assert result.food_name is not None
+    assert result.servings is not None
 
 
 @pytest.mark.integration
@@ -37,10 +37,10 @@ def test_food_get_v2_with_region(fatsecret_client):
     """Test foods.get_v2 with region parameter."""
     food_id = "4380"
     result = fatsecret_client.foods.get_v2(food_id=food_id, region="US")
-    assert isinstance(result, dict)
-    assert result["food_id"] == food_id
-    assert "food_name" in result
-    assert "servings" in result
+    assert result is not None
+    assert str(result.food_id) == food_id
+    assert result.food_name is not None
+    assert result.servings is not None
 
 
 @pytest.mark.integration
@@ -48,7 +48,7 @@ def test_food_get_v2_with_language(fatsecret_client):
     """Test foods.get_v2 with language parameter."""
     food_id = "4380"
     result = fatsecret_client.foods.get_v2(food_id=food_id, language="en")
-    assert isinstance(result, dict)
-    assert result["food_id"] == food_id
-    assert "food_name" in result
-    assert "servings" in result
+    assert result is not None
+    assert str(result.food_id) == food_id
+    assert result.food_name is not None
+    assert result.servings is not None


### PR DESCRIPTION
Release workflow on master failed because integration tests still used `result["food_id"]` after v3 flipped returns to typed `Food` models. This unblocks the v3.0.0 tag.