### PR TITLE
docs(v3): migration guide + fix XSD-required-but-actually-optional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 This library provides a lightweight python wrapper for the Fatsecret API with the goal of making it easier to visualize the data retrieved from the API. To that end, this library will usually return lists of identical elements for ease of plotting, discarding extra header fields that the Fatsecret API otherwise includes. All API calls return either a single or list of JSON dictionaries.
 
+## What's new in v3
+
+Methods on the namespaced surface (`fs.foods.*`, `fs.recipes.*`, `fs.diary.*`, `fs.profile.*`, `fs.weight.*`, `fs.exercises.*`) now return typed Pydantic v2 models — `Food`, `Recipe`, `Profile`, `FoodEntry`, `ExerciseEntry`, `Day`, etc. — instead of plain `dict`s. Use dotted attribute access (`food.food_id`, not `food["food_id"]`) or call `.to_dict()` on any model for the v2 dict shape. `pydantic>=2.7` is now a base dependency. See the [v3 migration guide](https://fatsecret.readthedocs.io/en/latest/migration-v3.html) for side-by-side examples and the four resources (Food Classification, Saved Meals, Native APIs, Feedback) that intentionally still return dicts.
+
 ## Installation
 
 ```sh

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,18 @@ Once you have created a session then you can start reading from Fatsecret's publ
 
     foods = fs.foods_search_v5("Tacos")        # latest upstream version
 
+Migrating to v3
+---------------
+
+v3.0 returns typed Pydantic models from the namespaced API surface
+instead of plain dicts. See the migration guide for side-by-side
+v2-vs-v3 examples and the ``.to_dict()`` escape hatch.
+
+.. toctree::
+    :maxdepth: 2
+
+    migration-v3
+
 OAuth Examples
 --------------
 

--- a/docs/migration-v3.rst
+++ b/docs/migration-v3.rst
@@ -1,0 +1,307 @@
+Migrating to v3
+===============
+
+What changed in v3
+------------------
+
+Methods on the namespaced ``Fatsecret`` surface (``fs.foods.*``,
+``fs.recipes.*``, ``fs.diary.*``, ``fs.profile.*``, ``fs.weight.*``,
+``fs.exercises.*``) that previously returned ``dict[str, Any]`` or
+``list[dict[str, Any]]`` now return typed Pydantic v2 models —
+``Food``, ``Recipe``, ``Profile``, ``FoodEntry``, ``ExerciseEntry``,
+``Exercise``, ``Day`` and friends. The wire-level behavior is
+unchanged; only the in-Python return shape is new. ``pydantic>=2.7``
+is now a base dependency.
+
+Quick fix for most callers
+--------------------------
+
+Replace square-bracket dict access with dotted attribute access:
+
+.. code-block:: python
+
+    # v2
+    food["food_id"]
+    food["food_name"]
+
+    # v3
+    food.food_id
+    food.food_name
+
+If you have a downstream consumer that genuinely needs the dict
+shape (JSON serialization, a templating layer, an existing
+``dict``-typed signature you can't change today) call ``.to_dict()``
+on the model. That's the one-line escape hatch:
+
+.. code-block:: python
+
+    payload_for_legacy_consumer = food.to_dict()
+
+``.to_dict()`` is ``model.model_dump(mode="json")`` under the hood, so
+``Decimal`` values come back as JSON-safe strings — same shape your
+v2 code was already handling off the wire.
+
+Side-by-side examples
+---------------------
+
+Single food lookup
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    food = fs.foods.get_v1(food_id=12345)
+
+    # v2
+    food["food_name"]
+    food["food_type"]
+    food["servings"]["serving"][0]["calories"]
+
+    # v3
+    food.food_name                            # str
+    food.food_type                            # Literal["Brand", "Generic"]
+    food.servings.serving[0].calories         # Decimal
+
+Food search
+~~~~~~~~~~~
+
+``search_v1`` returns a list of typed ``Food`` objects directly
+(the wrapping ``foods``/``results`` envelope is unwrapped for you):
+
+.. code-block:: python
+
+    foods = fs.foods.search_v1(search_expression="banana")
+
+    # v2
+    for entry in foods:
+        print(entry["food_id"], entry["food_name"])
+
+    # v3
+    for entry in foods:
+        print(entry.food_id, entry.food_name)   # int, str
+
+Diary entries
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    import datetime
+    today = datetime.date.today()
+    entries = fs.diary.entries_get_v2(date=today)   # list[FoodEntry]
+
+    # v2
+    for e in entries:
+        print(e["meal"], e["calories"], e["protein"])
+
+    # v3
+    for e in entries:
+        print(e.meal, e.calories, e.protein)
+        # e.meal     -> Literal["Breakfast", "Lunch", "Dinner", "Other"]
+        # e.calories -> Decimal (not float!)
+        # e.protein  -> Decimal
+
+Recipe lookup
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    recipe = fs.recipes.get_v1(recipe_id=88339)   # Recipe
+
+    # v2
+    recipe["recipe_name"]
+    recipe["recipe_nutrition"]["calories"]
+
+    # v3
+    recipe.recipe_name                            # str
+    recipe.recipe_nutrition.calories              # Decimal
+
+(``Recipe`` is a friendly alias for the XSD-derived ``RecipesRecipe``
+class. Either name imports the same model.)
+
+User profile
+~~~~~~~~~~~~
+
+.. code-block:: python
+
+    profile = fs.profile.get_v1()   # Profile
+
+    # v2
+    profile["last_weight_kg"]
+    profile["weight_measure"]
+
+    # v3
+    profile.last_weight_kg                        # Optional[Decimal]
+    profile.weight_measure                        # Optional[Literal["Kg", "Lb"]]
+
+Resources that still return dict
+--------------------------------
+
+Four resource families intentionally kept their ``dict`` return
+shape because the upstream XSD doesn't model them. Nothing changed
+for callers of these:
+
+- **Food Classification** (``fs.classification.*``) — brands,
+  categories, sub-categories.
+- **Saved Meals** (``fs.meals.*``) — saved meal CRUD and items.
+- **Native APIs** (``fs.native.*``) — image recognition, NLP.
+- **Feedback** (``fs.feedback.*``) — feedback submission.
+
+If we get an XSD (or a stable enough HTML overlay) for any of these
+in the future they'll be promoted to typed models in a minor
+release. The dict shape is the migration path; we won't reshape it.
+
+Mutators still return ``bool``
+------------------------------
+
+Methods that write rather than read return a plain success boolean,
+not a model. No change from v2:
+
+- ``fs.weight.update_v1(...)`` -> ``bool``
+- ``fs.diary.entry_create_v1(...)`` -> ``list[FoodEntry]`` (the
+  resulting entries, typed)
+- ``fs.diary.entry_edit_v1(...)`` -> ``bool``
+- ``fs.diary.entry_delete_v1(...)`` -> ``bool``
+- ``fs.recipes.add_favorite_v1(...)`` -> ``bool``
+- ``fs.recipes.delete_favorite_v1(...)`` -> ``bool``
+
+Type details worth knowing
+--------------------------
+
+``Decimal`` for nutrition macros
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Calories, protein, carbs, fat, micronutrients — all ``Decimal``,
+not ``float``. The XSD says ``xsd:decimal`` and we honor it because
+floating-point rounding in nutrition math compounds quickly across a
+day's worth of entries. Two consequences:
+
+- Arithmetic between a ``Decimal`` and a ``float`` raises
+  ``TypeError``. Use ``Decimal(str(my_float))`` to lift, or convert
+  the model value with ``float(entry.calories)`` if you genuinely
+  want lossy float math.
+- ``json.dumps(model)`` won't work — ``Decimal`` isn't
+  JSON-serializable by default. Use ``model.model_dump_json()`` or
+  ``json.dumps(model.to_dict())`` (``to_dict`` already invokes
+  ``model_dump(mode="json")`` which stringifies Decimals).
+
+``Literal`` for closed enums
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Where the XSD declares an enum, the field is a ``Literal[...]`` —
+the IDE autocompletes it and a typo lights up under mypy/pyright:
+
+- ``Food.food_type`` -> ``Literal["Brand", "Generic"]``
+- ``FoodEntry.meal`` -> ``Literal["Breakfast", "Lunch", "Dinner", "Other"]``
+- ``Profile.weight_measure`` -> ``Optional[Literal["Kg", "Lb"]]``
+- ``Profile.height_measure`` -> ``Optional[Literal["Cm", "Inch"]]``
+
+``Ternary`` for FatSecret's tri-state booleans
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A handful of fields (``Allergen.value``, ``Preference.value``) use
+FatSecret's quirky three-valued truthiness:
+
+.. code-block:: python
+
+    Ternary = Literal[-1, 0, 1, "Unknown", "True", "False"]
+
+Both numeric and string forms are accepted because the upstream API
+emits both depending on the endpoint version. Don't compare with
+``is True`` / ``is False`` — use ``== "True"`` / ``== 1`` or, more
+defensively, normalize via a small helper.
+
+``extra="allow"`` — schema drift is non-fatal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every model is configured with ``extra="allow"``. If FatSecret adds
+a new field tomorrow that we haven't regenerated for, the model
+preserves it (accessible via ``model.__pydantic_extra__``) instead of
+rejecting the response. Drift is detected by CI's
+``oas-regen-check``, not by runtime validation failures — your
+production code keeps working.
+
+The ``.to_dict()`` migration helper
+-----------------------------------
+
+Every model inherits a ``.to_dict()`` method that returns the v2
+dict shape:
+
+.. code-block:: python
+
+    food = fs.foods.get_v1(food_id=12345)
+    legacy_shape = food.to_dict()   # {"food_id": "12345", "food_name": "...", ...}
+
+Use it as a per-call escape hatch when migrating a large codebase
+incrementally. ``Decimal`` becomes a string (``mode="json"``),
+matching what v2 callers were already getting off the wire.
+
+Frequently broken patterns
+--------------------------
+
+Iterating like a dict
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    # v2 — works on dicts
+    for k, v in food.items():
+        ...
+
+    # v3 — Pydantic models aren't dicts
+    for k, v in food.model_dump().items():
+        ...
+
+JSON-serializing a model
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    # v2
+    json.dumps(food)
+
+    # v3 — pick one
+    food.model_dump_json()              # returns a JSON string directly
+    json.dumps(food.to_dict())          # round-trips through the dict shape
+
+``.get()`` with a default
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    # v2
+    brand = food.get("brand_name", "Unknown")
+
+    # v3 — use getattr or check Optional
+    brand = food.brand_name or "Unknown"
+    # or, if the field could be missing on a model with extra="allow":
+    brand = getattr(food, "brand_name", None) or "Unknown"
+
+Membership tests
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    # v2
+    if "brand_name" in food:
+        ...
+
+    # v3
+    if food.brand_name is not None:
+        ...
+
+Why typed models?
+-----------------
+
+- **IDE autocompletion.** ``food.<TAB>`` lists every field with its
+  type. No more guessing whether the key is ``food_name`` or
+  ``foodName`` or ``name``.
+- **Real types.** ``food.food_id`` is ``int``, not ``str``;
+  ``serving.calories`` is ``Decimal``, not whatever the wire happened
+  to send. Pydantic coerces both directions, so legacy fixtures that
+  serialized integers as strings still validate.
+- **Runtime validation catches schema drift.** When FatSecret changes
+  an XSD-typed field's shape (rename, type change), validation fails
+  loudly at the call site instead of silently propagating malformed
+  data into your business logic.
+- **Closed enums document themselves.** ``Literal["Brand", "Generic"]``
+  is the spec — your type checker will tell you if you compare against
+  the wrong string.

--- a/scripts/oas-sync/src/oas_sync/emit_models.py
+++ b/scripts/oas-sync/src/oas_sync/emit_models.py
@@ -344,10 +344,15 @@ def _build_class_from_complex(
             continue
         type_name = elem.get("type")
         inline = elem.find(XSD_NS + "complexType")
-        min_occ = elem.get("minOccurs", "1")
         max_occ = elem.get("maxOccurs", "1")
         is_list = max_occ == "unbounded" or (max_occ.isdigit() and int(max_occ) > 1)
-        optional = min_occ == "0"
+        # Force every element field to Optional with default=None. The XSD's
+        # "required" claim does not match FatSecret's live behaviour
+        # (e.g. `serving.is_default` is declared required but the live API
+        # often omits it). Tolerating drift here matches the `extra="allow"`
+        # philosophy on `_FS_Base` — accept real responses rather than
+        # raise ValidationError on a field FatSecret silently dropped.
+        optional = True
 
         annotation, imports, aliases, deps = _resolve_field_type(
             type_name, inline, simple_types, complex_types, pending_inline, class_name, name

--- a/src/fatsecret/models/_generated/exercise_diary.py
+++ b/src/fatsecret/models/_generated/exercise_diary.py
@@ -14,7 +14,7 @@ from .._common import _FS_Base
 class Day(_FS_Base):
     """Generated from XSD ``day``."""
 
-    date_int: int
+    date_int: Optional[int] = Field(default=None)
     calories: Optional[Decimal] = Field(default=None)
     carbohydrate: Optional[Decimal] = Field(default=None)
     protein: Optional[Decimal] = Field(default=None)
@@ -26,35 +26,35 @@ class Day(_FS_Base):
 class Exercise(_FS_Base):
     """Generated from XSD ``exercise``."""
 
-    exercise_id: int
-    exercise_name: str
+    exercise_id: Optional[int] = Field(default=None)
+    exercise_name: Optional[str] = Field(default=None)
 
 
 class ExerciseEntry(_FS_Base):
     """Generated from XSD ``exercise_entry``."""
 
-    is_template_value: bool
-    exercise_id: int
-    exercise_name: str
-    minutes: int
-    calories: Decimal
+    is_template_value: Optional[bool] = Field(default=None)
+    exercise_id: Optional[int] = Field(default=None)
+    exercise_name: Optional[str] = Field(default=None)
+    minutes: Optional[int] = Field(default=None)
+    calories: Optional[Decimal] = Field(default=None)
 
 
 class ExerciseEntries(_FS_Base):
     """Generated from XSD ``exercise_entries``."""
 
-    exercise_entry: List[ExerciseEntry]
+    exercise_entry: Optional[List[ExerciseEntry]] = Field(default=None)
 
 
 class ExerciseTypes(_FS_Base):
     """Generated from XSD ``exercise_types``."""
 
-    exercise: List[Exercise]
+    exercise: Optional[List[Exercise]] = Field(default=None)
 
 
 class Month(_FS_Base):
     """Generated from XSD ``month``."""
 
-    from_date_int: int
-    to_date_int: int
+    from_date_int: Optional[int] = Field(default=None)
+    to_date_int: Optional[int] = Field(default=None)
     day: Optional[List[Day]] = Field(default=None)

--- a/src/fatsecret/models/_generated/food_diary.py
+++ b/src/fatsecret/models/_generated/food_diary.py
@@ -14,7 +14,7 @@ from .._common import _FS_Base
 class Day(_FS_Base):
     """Generated from XSD ``day``."""
 
-    date_int: int
+    date_int: Optional[int] = Field(default=None)
     calories: Optional[Decimal] = Field(default=None)
     carbohydrate: Optional[Decimal] = Field(default=None)
     protein: Optional[Decimal] = Field(default=None)
@@ -26,18 +26,18 @@ class Day(_FS_Base):
 class FoodEntry(_FS_Base):
     """Generated from XSD ``food_entry``."""
 
-    food_entry_id: int
-    food_entry_description: str
-    date_int: int
-    meal: Literal['Breakfast', 'Lunch', 'Dinner', 'Other']
-    food_id: int
-    serving_id: int
-    number_of_units: Decimal
-    food_entry_name: str
-    calories: Decimal
-    carbohydrate: Decimal
-    protein: Decimal
-    fat: Decimal
+    food_entry_id: Optional[int] = Field(default=None)
+    food_entry_description: Optional[str] = Field(default=None)
+    date_int: Optional[int] = Field(default=None)
+    meal: Optional[Literal['Breakfast', 'Lunch', 'Dinner', 'Other']] = Field(default=None)
+    food_id: Optional[int] = Field(default=None)
+    serving_id: Optional[int] = Field(default=None)
+    number_of_units: Optional[Decimal] = Field(default=None)
+    food_entry_name: Optional[str] = Field(default=None)
+    calories: Optional[Decimal] = Field(default=None)
+    carbohydrate: Optional[Decimal] = Field(default=None)
+    protein: Optional[Decimal] = Field(default=None)
+    fat: Optional[Decimal] = Field(default=None)
     saturated_fat: Optional[Decimal] = Field(default=None)
     polyunsaturated_fat: Optional[Decimal] = Field(default=None)
     monounsaturated_fat: Optional[Decimal] = Field(default=None)
@@ -62,6 +62,6 @@ class FoodEntries(_FS_Base):
 class Month(_FS_Base):
     """Generated from XSD ``month``."""
 
-    from_date_int: int
-    to_date_int: int
+    from_date_int: Optional[int] = Field(default=None)
+    to_date_int: Optional[int] = Field(default=None)
     day: Optional[List[Day]] = Field(default=None)

--- a/src/fatsecret/models/_generated/foods.py
+++ b/src/fatsecret/models/_generated/foods.py
@@ -14,26 +14,26 @@ from .._common import _FS_Base, FoodType, Ternary
 class Allergen(_FS_Base):
     """Generated from XSD ``allergen``."""
 
-    id: int
-    name: str
-    value: Ternary
+    id: Optional[int] = Field(default=None)
+    name: Optional[str] = Field(default=None)
+    value: Optional[Ternary] = Field(default=None)
 
 
 class FoodEntry(_FS_Base):
     """Generated from XSD ``food_entry``."""
 
-    food_entry_id: int
-    food_entry_description: str
-    date_int: int
-    meal: Literal['Breakfast', 'Lunch', 'Dinner', 'Other']
-    food_id: int
-    serving_id: int
-    number_of_units: Decimal
-    food_entry_name: str
-    calories: Decimal
-    carbohydrate: Decimal
-    protein: Decimal
-    fat: Decimal
+    food_entry_id: Optional[int] = Field(default=None)
+    food_entry_description: Optional[str] = Field(default=None)
+    date_int: Optional[int] = Field(default=None)
+    meal: Optional[Literal['Breakfast', 'Lunch', 'Dinner', 'Other']] = Field(default=None)
+    food_id: Optional[int] = Field(default=None)
+    serving_id: Optional[int] = Field(default=None)
+    number_of_units: Optional[Decimal] = Field(default=None)
+    food_entry_name: Optional[str] = Field(default=None)
+    calories: Optional[Decimal] = Field(default=None)
+    carbohydrate: Optional[Decimal] = Field(default=None)
+    protein: Optional[Decimal] = Field(default=None)
+    fat: Optional[Decimal] = Field(default=None)
     saturated_fat: Optional[Decimal] = Field(default=None)
     polyunsaturated_fat: Optional[Decimal] = Field(default=None)
     monounsaturated_fat: Optional[Decimal] = Field(default=None)
@@ -52,45 +52,45 @@ class FoodEntry(_FS_Base):
 class FoodFoodSubCategories(_FS_Base):
     """Generated from XSD ``<inline FoodFoodSubCategories>``."""
 
-    food_sub_category: List[str]
+    food_sub_category: Optional[List[str]] = Field(default=None)
 
 
 class FoodImage(_FS_Base):
     """Generated from XSD ``food_image``."""
 
-    image_url: str
-    image_type: int
+    image_url: Optional[str] = Field(default=None)
+    image_type: Optional[int] = Field(default=None)
 
 
 class FoodSubCategories(_FS_Base):
     """Generated from XSD ``food_sub_categories``."""
 
-    food_sub_category: str
+    food_sub_category: Optional[str] = Field(default=None)
 
 
 class Preference(_FS_Base):
     """Generated from XSD ``preference``."""
 
-    id: int
-    name: str
-    value: Ternary
+    id: Optional[int] = Field(default=None)
+    name: Optional[str] = Field(default=None)
+    value: Optional[Ternary] = Field(default=None)
 
 
 class Serving(_FS_Base):
     """Generated from XSD ``serving``."""
 
-    serving_id: int
-    serving_description: str
-    serving_url: str
+    serving_id: Optional[int] = Field(default=None)
+    serving_description: Optional[str] = Field(default=None)
+    serving_url: Optional[str] = Field(default=None)
     metric_serving_amount: Optional[Decimal] = Field(default=None)
     metric_serving_unit: Optional[str] = Field(default=None)
-    number_of_units: Decimal
-    measurement_description: str
-    is_default: bool
-    calories: Decimal
-    carbohydrate: Decimal
-    protein: Decimal
-    fat: Decimal
+    number_of_units: Optional[Decimal] = Field(default=None)
+    measurement_description: Optional[str] = Field(default=None)
+    is_default: Optional[bool] = Field(default=None)
+    calories: Optional[Decimal] = Field(default=None)
+    carbohydrate: Optional[Decimal] = Field(default=None)
+    protein: Optional[Decimal] = Field(default=None)
+    fat: Optional[Decimal] = Field(default=None)
     saturated_fat: Optional[Decimal] = Field(default=None)
     polyunsaturated_fat: Optional[Decimal] = Field(default=None)
     monounsaturated_fat: Optional[Decimal] = Field(default=None)
@@ -111,7 +111,7 @@ class Serving(_FS_Base):
 class Allergens(_FS_Base):
     """Generated from XSD ``allergens``."""
 
-    allergen: Allergen
+    allergen: Optional[Allergen] = Field(default=None)
 
 
 class FoodEntries(_FS_Base):
@@ -123,41 +123,41 @@ class FoodEntries(_FS_Base):
 class FoodFoodImages(_FS_Base):
     """Generated from XSD ``<inline FoodFoodImages>``."""
 
-    food_image: List[FoodImage]
+    food_image: Optional[List[FoodImage]] = Field(default=None)
 
 
 class FoodImages(_FS_Base):
     """Generated from XSD ``food_images``."""
 
-    food_image: FoodImage
+    food_image: Optional[FoodImage] = Field(default=None)
 
 
 class FoodServings(_FS_Base):
     """Generated from XSD ``<inline FoodServings>``."""
 
-    serving: List[Serving]
+    serving: Optional[List[Serving]] = Field(default=None)
 
 
 class Preferences(_FS_Base):
     """Generated from XSD ``preferences``."""
 
-    preference: Preference
+    preference: Optional[Preference] = Field(default=None)
 
 
 class FoodAttributes(_FS_Base):
     """Generated from XSD ``food_attributes``."""
 
-    preferences: Preferences
+    preferences: Optional[Preferences] = Field(default=None)
 
 
 class Food(_FS_Base):
     """Generated from XSD ``food``."""
 
-    food_id: int
-    food_name: str
+    food_id: Optional[int] = Field(default=None)
+    food_name: Optional[str] = Field(default=None)
     brand_name: Optional[str] = Field(default=None)
-    food_type: FoodType
-    food_url: str
+    food_type: Optional[FoodType] = Field(default=None)
+    food_url: Optional[str] = Field(default=None)
     food_description: Optional[str] = Field(default=None)
     servings: Optional[FoodServings] = Field(default=None)
     food_sub_categories: Optional[FoodFoodSubCategories] = Field(default=None)
@@ -174,9 +174,9 @@ class FoodResults(_FS_Base):
 class Foods(_FS_Base):
     """Generated from XSD ``foods``."""
 
-    max_results: int
-    total_results: int
-    page_number: int
+    max_results: Optional[int] = Field(default=None)
+    total_results: Optional[int] = Field(default=None)
+    page_number: Optional[int] = Field(default=None)
     food: Optional[List[Food]] = Field(default=None)
 
 
@@ -189,7 +189,7 @@ class FoodsSearchResults(_FS_Base):
 class FoodsSearch(_FS_Base):
     """Generated from XSD ``foods_search``."""
 
-    max_results: int
-    total_results: int
-    page_number: int
-    results: FoodsSearchResults
+    max_results: Optional[int] = Field(default=None)
+    total_results: Optional[int] = Field(default=None)
+    page_number: Optional[int] = Field(default=None)
+    results: Optional[FoodsSearchResults] = Field(default=None)

--- a/src/fatsecret/models/_generated/recipes.py
+++ b/src/fatsecret/models/_generated/recipes.py
@@ -20,10 +20,10 @@ class RecipesRecipeRecipeIngredients(_FS_Base):
 class RecipesRecipeRecipeNutrition(_FS_Base):
     """Generated from XSD ``<inline RecipesRecipeRecipeNutrition>``."""
 
-    calories: Decimal
-    carbohydrate: Decimal
-    protein: Decimal
-    fat: Decimal
+    calories: Optional[Decimal] = Field(default=None)
+    carbohydrate: Optional[Decimal] = Field(default=None)
+    protein: Optional[Decimal] = Field(default=None)
+    fat: Optional[Decimal] = Field(default=None)
 
 
 class RecipesRecipeRecipeTypes(_FS_Base):
@@ -35,9 +35,9 @@ class RecipesRecipeRecipeTypes(_FS_Base):
 class RecipesRecipe(_FS_Base):
     """Generated from XSD ``<inline RecipesRecipe>``."""
 
-    recipe_id: int
-    recipe_name: str
-    recipe_description: str
+    recipe_id: Optional[int] = Field(default=None)
+    recipe_name: Optional[str] = Field(default=None)
+    recipe_description: Optional[str] = Field(default=None)
     recipe_image: Optional[str] = Field(default=None)
     recipe_nutrition: Optional[RecipesRecipeRecipeNutrition] = Field(default=None)
     recipe_ingredients: Optional[RecipesRecipeRecipeIngredients] = Field(default=None)
@@ -47,7 +47,7 @@ class RecipesRecipe(_FS_Base):
 class Recipes(_FS_Base):
     """Generated from XSD ``recipes``."""
 
-    max_results: int
-    total_results: int
-    page_number: int
-    recipe: RecipesRecipe
+    max_results: Optional[int] = Field(default=None)
+    total_results: Optional[int] = Field(default=None)
+    page_number: Optional[int] = Field(default=None)
+    recipe: Optional[RecipesRecipe] = Field(default=None)

--- a/src/fatsecret/models/_generated/weight_diary.py
+++ b/src/fatsecret/models/_generated/weight_diary.py
@@ -14,7 +14,7 @@ from .._common import _FS_Base
 class Day(_FS_Base):
     """Generated from XSD ``day``."""
 
-    date_int: int
+    date_int: Optional[int] = Field(default=None)
     calories: Optional[Decimal] = Field(default=None)
     carbohydrate: Optional[Decimal] = Field(default=None)
     protein: Optional[Decimal] = Field(default=None)
@@ -26,6 +26,6 @@ class Day(_FS_Base):
 class Month(_FS_Base):
     """Generated from XSD ``month``."""
 
-    from_date_int: int
-    to_date_int: int
+    from_date_int: Optional[int] = Field(default=None)
+    to_date_int: Optional[int] = Field(default=None)
     day: Optional[List[Day]] = Field(default=None)


### PR DESCRIPTION
Two related changes for v3.0:

## Migration guide
- New `docs/migration-v3.rst` — full v2→v3 migration with side-by-side examples per resource
- README "What's new in v3" callout
- Sphinx toctree wired up

## Fix: default all XSD-derived fields to Optional
v3.0.0 release was blocked because integration tests against the live API hit `ValidationError` on `serving.is_default` — XSD declares it required but FatSecret often omits it from real responses. Fix: emit every XSD element field as `Optional[X] = Field(default=None)`. Matches the `extra="allow"` philosophy on `_FS_Base` — accept real responses rather than reject on a field FatSecret silently dropped.

804 unit tests pass. Once this lands, v3.0.0 should tag cleanly.