### PR TITLE
ci(release): auto-trigger RTD build for each new release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,3 +294,35 @@ jobs:
           fi
           echo "::error::PyPI publish failed for a reason other than duplicate-file."
           exit 1
+
+      - name: Trigger Read the Docs build for the new tag
+        if: steps.version.outputs.skip == 'false'
+        env:
+          READTHEDOCS_TOKEN: ${{ secrets.READTHEDOCS_TOKEN }}
+          RTD_VERSION: ${{ steps.version.outputs.tag }}
+        run: |
+          # Activate the version (idempotent — RTD returns 204 whether it
+          # was already active or not) and trigger a build. RTD's GitHub
+          # webhook only builds versions that are already active, so new
+          # tags require this nudge to be visible in the version flyout.
+          set -euo pipefail
+          # First, sync versions so the freshly-pushed tag is known to RTD.
+          curl -sS -X POST \
+            -H "Authorization: Token ${READTHEDOCS_TOKEN}" \
+            "https://app.readthedocs.org/api/v3/projects/fatsecret/sync-versions/" \
+            -o /dev/null -w "sync-versions: HTTP %{http_code}\n"
+          # Give RTD a moment to ingest the tag.
+          sleep 20
+          # Activate.
+          curl -sS -X PATCH \
+            -H "Authorization: Token ${READTHEDOCS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"active":true,"hidden":false}' \
+            "https://app.readthedocs.org/api/v3/projects/fatsecret/versions/${RTD_VERSION}/" \
+            -o /dev/null -w "activate ${RTD_VERSION}: HTTP %{http_code}\n"
+          # Trigger build.
+          curl -sS -X POST \
+            -H "Authorization: Token ${READTHEDOCS_TOKEN}" \
+            "https://app.readthedocs.org/api/v3/projects/fatsecret/versions/${RTD_VERSION}/builds/" \
+            -o /tmp/rtd-build.json -w "trigger build: HTTP %{http_code}\n"
+          python3 -c "import json; b=json.load(open('/tmp/rtd-build.json')).get('build',{}); print(f\"  build id={b.get('id')} state={b.get('state',{}).get('code')}\")"


### PR DESCRIPTION
## Summary
After publishing a new tag to PyPI, the release workflow now also calls Read the Docs' v3 API to:

1. Sync versions (so RTD picks up the freshly-pushed tag).
2. Activate the new version (`active=true, hidden=false`).
3. Trigger a build for it.

## Why
RTD's GitHub webhook only fires builds for **already-active** versions. Newly-pushed tags arrive as inactive and never get built unless someone goes to the dashboard or hits the API manually. This step closes that loop — every release ships docs the same minute it ships to PyPI.

Discovered when v3.0.0 was tagged and pushed but never appeared in the RTD version flyout (the user had to ask "why don't I see v3?").

## Idempotency
- `sync-versions` is safe to re-run; PATCH-active returns 204 whether the version was already active.
- The build trigger is fine to re-run too — RTD just queues another build for that tag.

## Requires
`READTHEDOCS_TOKEN` repo secret. Already set.

## Test plan
- [ ] CI green.
- [ ] After merge, the release workflow fires on master push, cuts a new patch tag (this PR is `ci(release):` prefix, so the next bump is patch), the tag push fires another release run, and that run's "Trigger Read the Docs build" step succeeds.
- [ ] Verify the new tag appears in https://app.readthedocs.org/projects/fatsecret/versions/ as active and with a build in flight.