### PR TITLE
Revert "ci(release): auto-trigger RTD build for each new release tag (#140)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,35 +294,3 @@ jobs:
           fi
           echo "::error::PyPI publish failed for a reason other than duplicate-file."
           exit 1
-
-      - name: Trigger Read the Docs build for the new tag
-        if: steps.version.outputs.skip == 'false'
-        env:
-          READTHEDOCS_TOKEN: ${{ secrets.READTHEDOCS_TOKEN }}
-          RTD_VERSION: ${{ steps.version.outputs.tag }}
-        run: |
-          # Activate the version (idempotent — RTD returns 204 whether it
-          # was already active or not) and trigger a build. RTD's GitHub
-          # webhook only builds versions that are already active, so new
-          # tags require this nudge to be visible in the version flyout.
-          set -euo pipefail
-          # First, sync versions so the freshly-pushed tag is known to RTD.
-          curl -sS -X POST \
-            -H "Authorization: Token ${READTHEDOCS_TOKEN}" \
-            "https://app.readthedocs.org/api/v3/projects/fatsecret/sync-versions/" \
-            -o /dev/null -w "sync-versions: HTTP %{http_code}\n"
-          # Give RTD a moment to ingest the tag.
-          sleep 20
-          # Activate.
-          curl -sS -X PATCH \
-            -H "Authorization: Token ${READTHEDOCS_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d '{"active":true,"hidden":false}' \
-            "https://app.readthedocs.org/api/v3/projects/fatsecret/versions/${RTD_VERSION}/" \
-            -o /dev/null -w "activate ${RTD_VERSION}: HTTP %{http_code}\n"
-          # Trigger build.
-          curl -sS -X POST \
-            -H "Authorization: Token ${READTHEDOCS_TOKEN}" \
-            "https://app.readthedocs.org/api/v3/projects/fatsecret/versions/${RTD_VERSION}/builds/" \
-            -o /tmp/rtd-build.json -w "trigger build: HTTP %{http_code}\n"
-          python3 -c "import json; b=json.load(open('/tmp/rtd-build.json')).get('build',{}); print(f\"  build id={b.get('id')} state={b.get('state',{}).get('code')}\")"


### PR DESCRIPTION
## Why
PR #140 implemented auto-trigger via the release workflow. After landing it, we realized RTD's native **Automation Rules** are the canonical solution for this use case, and they're what comparable Python OSS projects use.

The user is configuring two Automation Rules on the RTD dashboard:
1. Match \`^v\\d+\\.\\d+\\.\\d+$\` (tag) → Activate version
2. Match same → Build version

That replaces the GH Actions step with zero CI overhead, no token in repo secrets, and faster propagation (RTD's webhook fires in seconds; we don't need \`sleep 20\` for sync).

Tradeoff accepted: configuration moves off-repo to the RTD dashboard. The clarity loss is worth the simpler, lower-attack-surface pipeline.

The \`READTHEDOCS_TOKEN\` repo secret can stay set or be deleted — it's no longer referenced by any workflow after this revert.

## Test plan
- [ ] CI green.
- [ ] After RTD Automation Rules are configured by the user, the next release should auto-activate + build on RTD without GH Actions touching it.