### PR TITLE
docs: regroup API by FatSecret guide categories (two-level hierarchy)

### DIFF
--- a/docs/_ext/fatsecret_oas.py
+++ b/docs/_ext/fatsecret_oas.py
@@ -2,9 +2,11 @@
 
 Reads ``docs/api-spec/openapi.generated.yaml`` at build time, maps each OAS
 operationId to its concrete Python method (resource sub-objects on a
-``Fatsecret`` instance, e.g. ``Fatsecret.foods.search_v5``), and emits one
-section per tag. Falls back to a flat ``autoclass`` block if the spec or
-pyyaml is missing so older tags / minimal checkouts still build.
+``Fatsecret`` instance, e.g. ``Fatsecret.foods.search_v5``), and emits a
+two-level structure: top-level guide categories (mirroring the layout of
+platform.fatsecret.com/docs/guides/) each containing one subsection per
+OAS tag. Falls back to a flat ``autoclass`` block if the spec or pyyaml
+is missing so older tags / minimal checkouts still build.
 """
 
 from __future__ import annotations
@@ -45,6 +47,22 @@ _TAG_TO_RESOURCES: dict[str, list[str]] = {
     "profile": ["profile", "profile_foods"],
     "feedback": ["feedback"],
 }
+
+# Two-level grouping: top-level guide category -> ordered list of OAS tags.
+# Mirrors the structure of platform.fatsecret.com/docs/guides/. Any OAS tag
+# not listed here falls through to a synthetic "Other" group (logged).
+_TAG_GROUPS: list[tuple[str, list[str]]] = [
+    ("Foods", ["food", "food_brands", "food_categories", "food_sub_categories", "foods"]),
+    ("Diary", ["food_entries", "food_entry", "exercise_entries", "exercise_entry"]),
+    ("Exercises", ["exercises"]),
+    ("Recipes", ["recipe", "recipe_types", "recipes"]),
+    ("Profile", ["profile"]),
+    ("Saved Meals (Premier)", ["saved_meal", "saved_meal_item", "saved_meal_items", "saved_meals"]),
+    ("Weight (Premier)", ["weight", "weights"]),
+    ("AI (Premier)", ["image", "natural"]),
+    ("Feedback", ["feedback"]),
+]
+
 
 _TAG_HEADING: dict[str, str] = {
     "food": "Food",
@@ -213,38 +231,61 @@ class FatsecretApiGroupsDirective(Directive):
         methods, classes = _resource_inventory(Fatsecret)
         groups = _collect_ops(spec)
 
-        tag_order = sorted(groups.keys())
-        if "Authentication" in tag_order:
-            tag_order.remove("Authentication")
-            tag_order.insert(0, "Authentication")
+        # Build ordered (group_name, [tag, ...]) list from the static mapping,
+        # then sweep up any OAS tags that weren't pre-assigned into "Other".
+        assigned: set[str] = {t for _g, tags in _TAG_GROUPS for t in tags}
+        present_tags = set(groups.keys())
+        leftovers = sorted(present_tags - assigned)
+        if leftovers:
+            _log.warning(
+                "fatsecret_oas: %d tag(s) not in _TAG_GROUPS, placing under 'Other': %s",
+                len(leftovers), ", ".join(leftovers),
+            )
+        # Authentication, if it ever appears, stays at the top of "Other".
+        if "Authentication" in leftovers:
+            leftovers.remove("Authentication")
+            leftovers.insert(0, "Authentication")
+
+        ordered_groups: list[tuple[str, list[str]]] = [
+            (gname, [t for t in tags if t in present_tags])
+            for gname, tags in _TAG_GROUPS
+        ]
+        if leftovers:
+            ordered_groups.append(("Other", leftovers))
 
         lines: list[str] = []
         unresolved: list[str] = []
         seen: set[str] = set()
 
-        for tag in tag_order:
-            heading = _TAG_HEADING.get(tag, tag)
-            lines.append(heading)
-            lines.append("-" * len(heading))
+        for group_name, tags in ordered_groups:
+            if not tags:
+                continue
+            lines.append(group_name)
+            lines.append("-" * len(group_name))
             lines.append("")
-            for op_id in sorted(set(groups[tag])):
-                resolved = _resolve(op_id, tag, methods, classes)
-                if resolved is None:
-                    unresolved.append(f"{tag}:{op_id}")
-                    lines.append(f"* ``{op_id}`` (no matching Python method)")
-                    lines.append("")
-                    continue
-                attr, mname, target = resolved
-                accessor = f"Fatsecret.{attr}.{mname}()"
-                if target in seen:
-                    lines.append(f"* ``{accessor}`` -- also tagged ``{tag}``.")
-                    lines.append("")
-                    continue
-                seen.add(target)
-                lines.append(f"**{accessor}**")
+            for tag in tags:
+                heading = _TAG_HEADING.get(tag, tag)
+                lines.append(heading)
+                lines.append("~" * len(heading))
                 lines.append("")
-                lines.append(f".. automethod:: {target}")
-                lines.append("")
+                for op_id in sorted(set(groups[tag])):
+                    resolved = _resolve(op_id, tag, methods, classes)
+                    if resolved is None:
+                        unresolved.append(f"{tag}:{op_id}")
+                        lines.append(f"* ``{op_id}`` (no matching Python method)")
+                        lines.append("")
+                        continue
+                    attr, mname, target = resolved
+                    accessor = f"Fatsecret.{attr}.{mname}()"
+                    if target in seen:
+                        lines.append(f"* ``{accessor}`` -- also tagged ``{tag}``.")
+                        lines.append("")
+                        continue
+                    seen.add(target)
+                    lines.append(f"**{accessor}**")
+                    lines.append("")
+                    lines.append(f".. automethod:: {target}")
+                    lines.append("")
 
         try:
             util = sorted(

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,7 +12,10 @@ warnings during development, run Python with::
 
 The endpoint methods below are exposed via resource sub-objects on a
 :class:`fatsecret.Fatsecret` instance -- e.g. ``fs.foods.search_v5(...)`` --
-and are grouped by their OpenAPI tag (sourced from
+and are grouped under top-level guide categories matching FatSecret's
+official documentation layout (`platform.fatsecret.com/docs/guides/
+<https://platform.fatsecret.com/docs/guides/>`_). Each guide contains one
+subsection per OpenAPI tag (sourced from
 ``docs/api-spec/openapi.generated.yaml``). Client-only helpers (auth
 handshake, session lifecycle, time conversion) are listed at the bottom
 under **Client utilities**.


### PR DESCRIPTION
## Summary

Restructure ``docs/api.html`` from a flat list of 24 OAS-tag sections to a two-level hierarchy: 10 top-level guide categories (mirroring [platform.fatsecret.com/docs/guides/](https://platform.fatsecret.com/docs/guides/)), each containing the related OAS-tag subsections.

**Before:** 24 flat ``<h2>`` sections (one per OAS tag + Client utilities).
**After:** 10 top-level ``<h2>`` sections, 23 ``<h3>`` subsections, plus Client utilities at the bottom.

## Mapping

| Top-level guide | OAS tags inside |
|---|---|
| Foods | food, food_brands, food_categories, food_sub_categories, foods |
| Diary | food_entries, food_entry, exercise_entries, exercise_entry |
| Exercises | exercises |
| Recipes | recipe, recipe_types, recipes |
| Profile | profile |
| Saved Meals (Premier) | saved_meal, saved_meal_item, saved_meal_items, saved_meals |
| Weight (Premier) | weight, weights |
| AI (Premier) | image, natural |
| Feedback | feedback |
| Client utilities | (Python-only helpers) |

All 23 OAS tags currently emitted by ``oas-sync`` fit the mapping; nothing falls through to ``Other``.

## Where the mapping lives

Hardcoded as the ``_TAG_GROUPS`` constant in ``docs/_ext/fatsecret_oas.py`` (Option B2).

``docs/api-spec/openapi.generated.yaml`` is fully rewritten by ``scripts/oas-sync`` on every run, so adding ``x-tagGroups`` there (Option A) would be wiped. Teaching ``oas-sync`` to inject the mapping (Option B1) splits responsibility for an entirely doc-presentation concern across two tools; keeping it inside the Sphinx extension is contained and survives regeneration.

If a future ``oas-sync`` run adds a tag not in ``_TAG_GROUPS``, the extension logs a warning and places the tag under a synthetic ``Other`` group.

## Test plan

- [x] ``uv run sphinx-build -b html -W docs docs/_build/html`` builds clean (no warnings).
- [x] ``api.html`` contains 10 ``<h2>`` (9 guides + Client utilities), 23 ``<h3>`` matching OAS tags.
- [x] Method autodoc entries render inside their h3 subsections.
- [ ] Spot-check the rendered page after RTD builds the preview.