### PR TITLE
chore(oas): add x-fatsecret-typed-response extension and codegen policy

### DIFF
--- a/docs/api-spec/openapi.yaml
+++ b/docs/api-spec/openapi.yaml
@@ -1004,6 +1004,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#exercise_entries.get:
     get:
       deprecated: true
@@ -1040,6 +1041,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#exercise_entries.get.v2:
     get:
       operationId: exercise_entries_get_v2
@@ -1075,6 +1077,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#exercise_entries.get_month:
     get:
       deprecated: true
@@ -1111,6 +1114,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#exercise_entries.get_month.v2:
     get:
       operationId: exercise_entries_get_month_v2
@@ -1146,6 +1150,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#exercise_entries.save_template:
     post:
       operationId: exercise_entries_save_template_v1
@@ -1190,6 +1195,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#exercise_entry.edit:
     put:
       operationId: exercise_entry_edit_v1
@@ -1264,6 +1270,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#exercises.get:
     get:
       deprecated: true
@@ -1308,6 +1315,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#exercises.get.v2:
     get:
       operationId: exercises_get_v2
@@ -1351,6 +1359,7 @@ paths:
       tags:
       - Exercise Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food.add_favorite:
     post:
       operationId: food_add_favorite_v1
@@ -1401,6 +1410,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food.create:
     post:
       deprecated: true
@@ -1598,6 +1608,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food.create.v2:
     post:
       operationId: food_create_v2
@@ -1800,6 +1811,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food.delete_favorite:
     delete:
       operationId: food_delete_favorite_v1
@@ -1850,6 +1862,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food.find_id_for_barcode:
     get:
       operationId: food_find_id_for_barcode_v1
@@ -1900,6 +1913,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food.find_id_for_barcode.v2:
     get:
       operationId: food_find_id_for_barcode_v2
@@ -1978,6 +1992,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food.get:
     get:
       deprecated: true
@@ -2041,6 +2056,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food.get.v2:
     get:
       deprecated: true
@@ -2104,6 +2120,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food.get.v3:
     get:
       deprecated: true
@@ -2167,6 +2184,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food.get.v4:
     get:
       deprecated: true
@@ -2245,6 +2263,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food.get.v5:
     get:
       operationId: food_get_v5
@@ -2322,6 +2341,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food_brands.get:
     get:
       deprecated: true
@@ -2380,6 +2400,7 @@ paths:
       tags:
       - Food Classification
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_brands.get.v2:
     get:
       operationId: food_brands_get_v2
@@ -2437,6 +2458,7 @@ paths:
       tags:
       - Food Classification
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_categories.get:
     get:
       deprecated: true
@@ -2481,6 +2503,7 @@ paths:
       tags:
       - Food Classification
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_categories.get.v2:
     get:
       operationId: food_categories_get_v2
@@ -2524,6 +2547,7 @@ paths:
       tags:
       - Food Classification
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_entries.copy:
     post:
       operationId: food_entries_copy_v1
@@ -2572,6 +2596,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_entries.copy_saved_meal:
     post:
       operationId: food_entries_copy_saved_meal_v1
@@ -2619,6 +2644,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_entries.get:
     get:
       deprecated: true
@@ -2661,6 +2687,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food_entries.get.v2:
     get:
       operationId: food_entries_get_v2
@@ -2702,6 +2729,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food_entries.get_month:
     get:
       deprecated: true
@@ -2738,6 +2766,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food_entries.get_month.v2:
     get:
       operationId: food_entries_get_month_v2
@@ -2773,6 +2802,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food_entry.create:
     post:
       operationId: food_entry_create_v1
@@ -2842,6 +2872,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#food_entry.delete:
     delete:
       operationId: food_entry_delete_v1
@@ -2877,6 +2908,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_entry.edit:
     put:
       operationId: food_entry_edit_v1
@@ -2940,6 +2972,7 @@ paths:
       tags:
       - Food Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_sub_categories.get:
     get:
       deprecated: true
@@ -2990,6 +3023,7 @@ paths:
       tags:
       - Food Classification
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#food_sub_categories.get.v2:
     get:
       operationId: food_sub_categories_get_v2
@@ -3039,6 +3073,7 @@ paths:
       tags:
       - Food Classification
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#foods.autocomplete:
     get:
       deprecated: true
@@ -3090,6 +3125,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#foods.autocomplete.v2:
     get:
       operationId: foods_autocomplete_v2
@@ -3140,6 +3176,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#foods.get_favorites:
     get:
       deprecated: true
@@ -3170,6 +3207,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.get_favorites.v2:
     get:
       operationId: foods_get_favorites_v2
@@ -3199,6 +3237,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.get_most_eaten:
     get:
       deprecated: true
@@ -3235,6 +3274,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.get_most_eaten.v2:
     get:
       operationId: foods_get_most_eaten_v2
@@ -3270,6 +3310,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.get_recently_eaten:
     get:
       deprecated: true
@@ -3306,6 +3347,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.get_recently_eaten.v2:
     get:
       operationId: foods_get_recently_eaten_v2
@@ -3341,6 +3383,7 @@ paths:
       tags:
       - Profile Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.search:
     get:
       operationId: foods_search_v1
@@ -3413,6 +3456,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.search.v2:
     get:
       deprecated: true
@@ -3489,6 +3533,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.search.v3:
     get:
       deprecated: true
@@ -3580,6 +3625,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.search.v4:
     get:
       deprecated: true
@@ -3671,6 +3717,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#foods.search.v5:
     get:
       operationId: foods_search_v5
@@ -3768,6 +3815,7 @@ paths:
       tags:
       - Foods
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#profile.create:
     post:
       operationId: profile_create_v1
@@ -3804,6 +3852,7 @@ paths:
       tags:
       - Profile Auth
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#profile.get:
     get:
       operationId: profile_get_v1
@@ -3833,6 +3882,7 @@ paths:
       tags:
       - Profile Auth
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#profile.get_auth:
     get:
       operationId: profile_get_auth_v1
@@ -3869,6 +3919,7 @@ paths:
       tags:
       - Profile Auth
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#recipe.add_favorite:
     post:
       operationId: recipe_add_favorite_v1
@@ -3904,6 +3955,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#recipe.delete_favorite:
     delete:
       operationId: recipe_delete_favorite_v1
@@ -3939,6 +3991,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#recipe.get:
     get:
       deprecated: true
@@ -3982,6 +4035,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#recipe.get.v2:
     get:
       operationId: recipe_get_v2
@@ -4024,6 +4078,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#recipe_types.get:
     get:
       deprecated: true
@@ -4054,6 +4109,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#recipe_types.get.v2:
     get:
       operationId: recipe_types_get_v2
@@ -4097,6 +4153,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#recipes.get_favorites:
     get:
       deprecated: true
@@ -4127,6 +4184,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#recipes.get_favorites.v2:
     get:
       operationId: recipes_get_favorites_v2
@@ -4156,6 +4214,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#recipes.search:
     get:
       deprecated: true
@@ -4211,6 +4270,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#recipes.search.v2:
     get:
       deprecated: true
@@ -4340,6 +4400,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#recipes.search.v3:
     get:
       operationId: recipes_search_v3
@@ -4484,6 +4545,7 @@ paths:
       tags:
       - Recipes
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#saved_meal.create:
     post:
       operationId: saved_meal_create_v1
@@ -4531,6 +4593,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meal.delete:
     delete:
       operationId: saved_meal_delete_v1
@@ -4566,6 +4629,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meal.edit:
     put:
       operationId: saved_meal_edit_v1
@@ -4619,6 +4683,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meal_item.add:
     post:
       operationId: saved_meal_item_add_v1
@@ -4681,6 +4746,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meal_item.delete:
     delete:
       operationId: saved_meal_item_delete_v1
@@ -4716,6 +4782,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meal_item.edit:
     put:
       operationId: saved_meal_item_edit_v1
@@ -4766,6 +4833,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meal_items.get:
     get:
       deprecated: true
@@ -4802,6 +4870,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meal_items.get.v2:
     get:
       operationId: saved_meal_items_get_v2
@@ -4837,6 +4906,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meals.get:
     get:
       deprecated: true
@@ -4873,6 +4943,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#saved_meals.get.v2:
     get:
       operationId: saved_meals_get_v2
@@ -4908,6 +4979,7 @@ paths:
       tags:
       - Saved Meals
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#weight.update:
     post:
       operationId: weight_update_v1
@@ -4982,6 +5054,7 @@ paths:
       tags:
       - Weight Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   /rest/server.api#weights.get_month:
     get:
       deprecated: true
@@ -5018,6 +5091,7 @@ paths:
       tags:
       - Weight Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   /rest/server.api#weights.get_month.v2:
     get:
       operationId: weights_get_month_v2
@@ -5053,6 +5127,7 @@ paths:
       tags:
       - Weight Diary
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: true
   https://platform.fatsecret.com/rest/feedback/v1:
     post:
       operationId: feedback_v1
@@ -5148,6 +5223,7 @@ paths:
       tags:
       - Feedback
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   https://platform.fatsecret.com/rest/image-recognition/v1:
     post:
       operationId: image_recognition_v1
@@ -5239,6 +5315,7 @@ paths:
       tags:
       - Native APIs
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   https://platform.fatsecret.com/rest/image-recognition/v2:
     post:
       operationId: image_recognition_v2
@@ -5330,6 +5407,7 @@ paths:
       tags:
       - Native APIs
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
   https://platform.fatsecret.com/rest/natural-language-processing/v1:
     post:
       operationId: natural_language_processing_v1
@@ -5422,6 +5500,7 @@ paths:
       tags:
       - Native APIs
       x-fatsecret-premier: true
+      x-fatsecret-typed-response: false
 security:
 - oauth2:
   - basic

--- a/scripts/oas-sync/CODEGEN-POLICY.md
+++ b/scripts/oas-sync/CODEGEN-POLICY.md
@@ -1,0 +1,63 @@
+# Codegen policy
+
+Files under these paths are AUTO-GENERATED. Do NOT hand-edit:
+
+- `src/fatsecret/models/_generated/`
+- `src/fatsecret/resources/_generated/`
+- `docs/api-spec/openapi.yaml`
+- `docs/api-spec/raw/*.yaml`
+
+Hand edits get clobbered on the next `oas-sync` run. The
+`oas-regen-check` CI gate enforces byte-identity between the committed
+files and the result of a fresh pipeline run.
+
+## How to add coverage for a new method
+
+1. If the method is missing from the OAS, extend the HTML scraper or
+   add the doc URL to the sitemap source under `scripts/oas-sync/`.
+2. Run `uv run oas-sync sync` (from `scripts/oas-sync/`) to refresh the
+   raw YAMLs and the assembled `docs/api-spec/openapi.yaml`.
+3. Run `uv run oas-sync emit-resource <Tag>` to regenerate the resource
+   wrapper for the corresponding tag.
+
+## How to add a typed Pydantic model
+
+1. The XSD must declare the response shape. If FatSecret's XSD doesn't
+   model it, the method stays as `dict`. We DO NOT hand-write Pydantic
+   models. Use the dict path until upstream XSD coverage appears.
+2. Add the seed types to `_<resource>_SEED_TYPES` in `emit_models.py`.
+3. Run `uv run oas-sync emit-models <resource>`.
+4. Add the response shape to `RESPONSE_MODEL_MAP` in
+   `scripts/oas-sync/src/oas_sync/model_coverage.py`. This is the single
+   source of truth — both the resource codegen and the OAS
+   `x-fatsecret-typed-response` vendor extension read from it.
+5. Re-run `uv run oas-sync emit-resource <Tag>` and
+   `uv run oas-sync assemble` (or `sync`) so the generated wrapper and
+   the OAS flag agree.
+
+## Why no hand-written models?
+
+- **Drift**: hand-written models would silently fall out of sync with
+  the XSD as FatSecret evolves.
+- **Audit**: the codegen pipeline is the single auditable step. Every
+  change to the surface flows through it.
+- **Determinism**: the `oas-regen-check` CI gate proves the committed
+  output matches a fresh run. Hand edits would break that gate.
+
+## Hand-written escape hatches
+
+`src/fatsecret/resources/<name>.py` (NOT `_generated/`) is the place
+for per-resource hand-tuned overrides — for example dotted-key
+parameter translations, response unwrapping that the codegen can't
+infer, or convenience wrappers. These extend the generated class via
+subclassing. They are reviewed and preserved across regenerations.
+
+## Discovering typed vs dict coverage programmatically
+
+Each operation in `docs/api-spec/openapi.yaml` carries a boolean
+`x-fatsecret-typed-response` flag. `true` means the resource wrapper
+returns a Pydantic model (or `list[Model]` / `Optional[Model]`);
+`false` means the wrapper returns the raw FatSecret response shape as
+`dict` / `list[dict]`. The flag is always present — never inferred
+from a missing key. The human-facing companion table lives in
+`docs/migration-v3.rst`.

--- a/scripts/oas-sync/src/oas_sync/assemble.py
+++ b/scripts/oas-sync/src/oas_sync/assemble.py
@@ -19,6 +19,8 @@ from typing import Any
 import yaml
 
 from .config import OUT_RAW_DIR, REPO_ROOT
+from .emit_resource import derive_unwrap
+from .model_coverage import RESPONSE_MODEL_MAP
 
 log = logging.getLogger(__name__)
 
@@ -463,7 +465,8 @@ def _build_operation(
 
     # Response schema: register one schema per operation, flat.
     schema_name = _schema_name(method, version)
-    schemas[schema_name] = _response_schema_from_block(endpoint.get("response"))
+    response_schema = _response_schema_from_block(endpoint.get("response"))
+    schemas[schema_name] = response_schema
 
     responses: dict[str, Any] = {
         "200": {
@@ -475,12 +478,21 @@ def _build_operation(
         "default": {"$ref": "#/components/responses/Error"},
     }
 
+    tag = _tag_for_endpoint(category, method)
+    unwrap_path, list_key, _is_mutator = derive_unwrap(response_schema)
+    has_typed_model = (tag, tuple(unwrap_path), list_key) in RESPONSE_MODEL_MAP
+
     operation: dict[str, Any] = {
         "operationId": op_id,
         "responses": responses,
         "security": _security_for(endpoint),
         "summary": summary,
-        "tags": [_tag_for_endpoint(category, method)],
+        "tags": [tag],
+        # Machine-readable companion to the typed/dict split documented for
+        # humans in docs/migration-v3.rst.  Always emitted (boolean) so
+        # programmatic consumers can discover coverage without inferring
+        # from a missing key. Source of truth: model_coverage.py.
+        "x-fatsecret-typed-response": has_typed_model,
     }
     if parameters:
         operation["parameters"] = parameters

--- a/scripts/oas-sync/src/oas_sync/emit_resource.py
+++ b/scripts/oas-sync/src/oas_sync/emit_resource.py
@@ -25,6 +25,7 @@ from typing import Any
 import yaml
 
 from .config import REPO_ROOT
+from .model_coverage import RESPONSE_MODEL_MAP as _RESPONSE_MODEL_MAP
 
 log = logging.getLogger(__name__)
 
@@ -87,49 +88,11 @@ _TAG_SLUG_MAP = {
 # Phase 2: response-model wrapping registry
 # ---------------------------------------------------------------------------
 #
-# Maps (tag, unwrap_path_tuple, list_key) -> (model_module, model_class).
-# When an entry exists, the generated method wraps the unwrapped raw
-# payload in ``Model.model_validate(raw)`` (singular) or
-# ``[Model.model_validate(r) for r in raw]`` (list), and the return type
-# annotation becomes the model class instead of ``Any``/``list``.
-#
-# Resources without XSD coverage (food_classification, saved_meals,
-# weight_diary's non-month endpoints, native_apis, feedback) have no
-# entries here and continue to return raw ``dict``/``list[dict]``.
-#
-# ``model_module`` is the name of the file under
-# ``fatsecret.models._generated`` (also re-exported via
-# ``fatsecret.models``).
-_RESPONSE_MODEL_MAP: dict[
-    tuple[str, tuple[str, ...], str | None],
-    tuple[str, str],
-] = {
-    # Foods (singular)
-    ("Foods", ("food",), None): ("foods", "Food"),
-    # Foods (list / search variants)
-    ("Foods", ("foods",), "food"): ("foods", "Food"),
-    ("Foods", ("foods_search", "results"), "food"): ("foods", "Food"),
-    # Profile Foods (same Food model)
-    ("Profile Foods", ("foods",), "food"): ("foods", "Food"),
-    # Recipes
-    ("Recipes", ("recipe",), None): ("recipes", "RecipesRecipe"),
-    ("Recipes", ("recipes",), "recipe"): ("recipes", "RecipesRecipe"),
-    # Profile Auth
-    ("Profile Auth", ("profile",), None): ("profile_auth", "Profile"),
-    # Food Diary
-    ("Food Diary", ("food_entries",), "food_entry"): ("food_diary", "FoodEntry"),
-    ("Food Diary", ("month",), "day"): ("food_diary", "Day"),
-    # Exercise Diary
-    ("Exercise Diary", ("exercise_entries",), "exercise_entry"): (
-        "exercise_diary", "ExerciseEntry",
-    ),
-    ("Exercise Diary", ("exercise_types",), "exercise"): (
-        "exercise_diary", "Exercise",
-    ),
-    ("Exercise Diary", ("month",), "day"): ("exercise_diary", "Day"),
-    # Weight Diary (only get_month is XSD-covered)
-    ("Weight Diary", ("month",), "day"): ("weight_diary", "Day"),
-}
+# The (tag, unwrap_path_tuple, list_key) -> (model_module, model_class)
+# coverage map lives in ``model_coverage.RESPONSE_MODEL_MAP`` so that
+# ``assemble.py`` can stamp the same coverage signal onto the OAS as an
+# ``x-fatsecret-typed-response`` vendor extension. Imported above as
+# ``_RESPONSE_MODEL_MAP`` to keep the existing call sites unchanged.
 
 
 # ---------------------------------------------------------------------------
@@ -314,6 +277,18 @@ def _extract_method(
     unwrap_path, list_key, is_mutator = derive_unwrap(schema)
 
     model = _RESPONSE_MODEL_MAP.get((tag, tuple(unwrap_path), list_key))
+    docstring = _docstring_for(operation)
+    # Surface the typed/dict split in IDE tooltips.  Methods that lack a
+    # Pydantic model return the raw FatSecret response shape; flag them so
+    # users don't have to cross-reference the migration guide.  Mutators
+    # already advertise their ``bool`` return via the type annotation, so
+    # they don't need the note.
+    if model is None and not is_mutator:
+        note = (
+            "No typed model — returns the raw FatSecret response shape. "
+            "See ``docs/migration-v3.rst`` for details."
+        )
+        docstring = f"{note} {docstring}".strip()
     return {
         "method_name": _method_name_for(tag, op_id),
         "operation_id": op_id,
@@ -326,7 +301,7 @@ def _extract_method(
         "unwrap_path": list(unwrap_path),
         "list_key": list_key,
         "is_mutator": is_mutator,
-        "docstring": _docstring_for(operation),
+        "docstring": docstring,
         # (model_module, model_class) when this method's response is
         # XSD-modelled; ``None`` when it falls back to a raw dict.
         "model": model,

--- a/scripts/oas-sync/src/oas_sync/model_coverage.py
+++ b/scripts/oas-sync/src/oas_sync/model_coverage.py
@@ -1,0 +1,55 @@
+"""Single source of truth for typed-response coverage.
+
+Maps ``(tag, unwrap_path_tuple, list_key)`` to ``(model_module, model_class)``.
+When an entry exists, the generated resource method wraps the unwrapped raw
+payload via ``Model.model_validate(...)`` and the return-type annotation
+becomes the model class (or ``list[Model]`` / ``Optional[Model]``).
+
+Operations whose tuple is *not* in the map continue to return raw
+``dict`` / ``list[dict]``.
+
+Both ``emit_resource.py`` (codegen of the resource wrappers) and
+``assemble.py`` (which stamps an ``x-fatsecret-typed-response`` vendor
+extension on every operation) read from this map. Keeping it in one
+place ensures the OAS flag and the generated Python stay in lockstep.
+"""
+
+from __future__ import annotations
+
+
+# Resources without XSD coverage (Food Classification, Saved Meals,
+# Weight Diary's non-month endpoints, Native APIs, Feedback) have no
+# entries here and continue to return raw ``dict`` / ``list[dict]``.
+RESPONSE_MODEL_MAP: dict[
+    tuple[str, tuple[str, ...], str | None],
+    tuple[str, str],
+] = {
+    # Foods (singular)
+    ("Foods", ("food",), None): ("foods", "Food"),
+    # Foods (list / search variants)
+    ("Foods", ("foods",), "food"): ("foods", "Food"),
+    ("Foods", ("foods_search", "results"), "food"): ("foods", "Food"),
+    # Profile Foods (same Food model)
+    ("Profile Foods", ("foods",), "food"): ("foods", "Food"),
+    # Recipes
+    ("Recipes", ("recipe",), None): ("recipes", "RecipesRecipe"),
+    ("Recipes", ("recipes",), "recipe"): ("recipes", "RecipesRecipe"),
+    # Profile Auth
+    ("Profile Auth", ("profile",), None): ("profile_auth", "Profile"),
+    # Food Diary
+    ("Food Diary", ("food_entries",), "food_entry"): ("food_diary", "FoodEntry"),
+    ("Food Diary", ("month",), "day"): ("food_diary", "Day"),
+    # Exercise Diary
+    ("Exercise Diary", ("exercise_entries",), "exercise_entry"): (
+        "exercise_diary", "ExerciseEntry",
+    ),
+    ("Exercise Diary", ("exercise_types",), "exercise"): (
+        "exercise_diary", "Exercise",
+    ),
+    ("Exercise Diary", ("month",), "day"): ("exercise_diary", "Day"),
+    # Weight Diary (only get_month is XSD-covered)
+    ("Weight Diary", ("month",), "day"): ("weight_diary", "Day"),
+}
+
+
+__all__ = ["RESPONSE_MODEL_MAP"]

--- a/src/fatsecret/resources/_generated/classification.py
+++ b/src/fatsecret/resources/_generated/classification.py
@@ -18,7 +18,7 @@ class ClassificationResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """food_brands.get (v1). DEPRECATED upstream. Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food_brands.get (v1). DEPRECATED upstream. Premier-only."""
         params: dict[str, Any] = {"method": "food_brands.get"}
         params["starts_with"] = starts_with
         self._client._set_optional(
@@ -40,7 +40,7 @@ class ClassificationResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """food_brands.get (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food_brands.get (v2). Premier-only."""
         params: dict[str, Any] = {"method": "food_brands.get.v2"}
         params["starts_with"] = starts_with
         self._client._set_optional(
@@ -60,7 +60,7 @@ class ClassificationResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """food_categories.get (v1). DEPRECATED upstream. Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food_categories.get (v1). DEPRECATED upstream. Premier-only."""
         params: dict[str, Any] = {"method": "food_categories.get"}
         self._client._set_optional(
             params,
@@ -78,7 +78,7 @@ class ClassificationResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """food_categories.get (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food_categories.get (v2). Premier-only."""
         params: dict[str, Any] = {"method": "food_categories.get.v2"}
         self._client._set_optional(
             params,
@@ -97,7 +97,7 @@ class ClassificationResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """food_sub_categories.get (v1). DEPRECATED upstream. Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food_sub_categories.get (v1). DEPRECATED upstream. Premier-only."""
         params: dict[str, Any] = {"method": "food_sub_categories.get"}
         params["food_category_id"] = food_category_id
         self._client._set_optional(
@@ -117,7 +117,7 @@ class ClassificationResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """food_sub_categories.get (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food_sub_categories.get (v2). Premier-only."""
         params: dict[str, Any] = {"method": "food_sub_categories.get.v2"}
         params["food_category_id"] = food_category_id
         self._client._set_optional(

--- a/src/fatsecret/resources/_generated/feedback.py
+++ b/src/fatsecret/resources/_generated/feedback.py
@@ -24,7 +24,7 @@ class FeedbackResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> Any:
-        """feedback (v1). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. feedback (v1). Premier-only."""
         body: dict[str, Any] = {}
         body["barcode"] = barcode
         body["issue_type_id"] = issue_type_id

--- a/src/fatsecret/resources/_generated/foods.py
+++ b/src/fatsecret/resources/_generated/foods.py
@@ -19,7 +19,7 @@ class FoodsResource(BaseResource):
         max_results: Optional[int] = None,
         region: Optional[str] = None,
     ) -> list:
-        """foods.autocomplete (v1). DEPRECATED upstream. Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. foods.autocomplete (v1). DEPRECATED upstream. Premier-only."""
         params: dict[str, Any] = {"method": "foods.autocomplete"}
         params["expression"] = expression
         self._client._set_optional(
@@ -39,7 +39,7 @@ class FoodsResource(BaseResource):
         max_results: Optional[int] = None,
         region: Optional[str] = None,
     ) -> list:
-        """foods.autocomplete (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. foods.autocomplete (v2). Premier-only."""
         params: dict[str, Any] = {"method": "foods.autocomplete.v2"}
         params["expression"] = expression
         self._client._set_optional(
@@ -59,7 +59,7 @@ class FoodsResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> Any:
-        """food.find_id_for_barcode (v1). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food.find_id_for_barcode (v1). Premier-only."""
         params: dict[str, Any] = {"method": "food.find_id_for_barcode"}
         params["barcode"] = barcode
         self._client._set_optional(

--- a/src/fatsecret/resources/_generated/meals.py
+++ b/src/fatsecret/resources/_generated/meals.py
@@ -17,7 +17,7 @@ class MealsResource(BaseResource):
         saved_meal_description: Optional[str] = None,
         meals: Optional[str] = None,
     ) -> Any:
-        """saved_meal.create (v1). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. saved_meal.create (v1). Premier-only."""
         params: dict[str, Any] = {"method": "saved_meal.create"}
         params["saved_meal_name"] = saved_meal_name
         self._client._set_optional(
@@ -66,7 +66,7 @@ class MealsResource(BaseResource):
         self,
         meal: Optional[str] = None,
     ) -> list:
-        """saved_meals.get (v1). DEPRECATED upstream. Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. saved_meals.get (v1). DEPRECATED upstream. Premier-only."""
         params: dict[str, Any] = {"method": "saved_meals.get"}
         self._client._set_optional(
             params,
@@ -82,7 +82,7 @@ class MealsResource(BaseResource):
         self,
         meal: Optional[str] = None,
     ) -> list:
-        """saved_meals.get (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. saved_meals.get (v2). Premier-only."""
         params: dict[str, Any] = {"method": "saved_meals.get.v2"}
         self._client._set_optional(
             params,
@@ -102,7 +102,7 @@ class MealsResource(BaseResource):
         serving_id: int,
         number_of_units: float,
     ) -> Any:
-        """saved_meal_item.add (v1). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. saved_meal_item.add (v1). Premier-only."""
         params: dict[str, Any] = {"method": "saved_meal_item.add"}
         params["saved_meal_id"] = saved_meal_id
         params["food_id"] = food_id
@@ -146,7 +146,7 @@ class MealsResource(BaseResource):
         self,
         saved_meal_id: int,
     ) -> list:
-        """saved_meal_items.get (v1). DEPRECATED upstream. Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. saved_meal_items.get (v1). DEPRECATED upstream. Premier-only."""
         params: dict[str, Any] = {"method": "saved_meal_items.get"}
         params["saved_meal_id"] = saved_meal_id
         payload = self._client._call(params)
@@ -157,7 +157,7 @@ class MealsResource(BaseResource):
         self,
         saved_meal_id: int,
     ) -> list:
-        """saved_meal_items.get (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. saved_meal_items.get (v2). Premier-only."""
         params: dict[str, Any] = {"method": "saved_meal_items.get.v2"}
         params["saved_meal_id"] = saved_meal_id
         payload = self._client._call(params)

--- a/src/fatsecret/resources/_generated/native.py
+++ b/src/fatsecret/resources/_generated/native.py
@@ -24,7 +24,7 @@ class NativeResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """image.recognition (v1). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. image.recognition (v1). Premier-only."""
         body: dict[str, Any] = {}
         body["image_b64"] = image_b64
         body["eaten_foods.food_id"] = eaten_foods_food_id
@@ -58,7 +58,7 @@ class NativeResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """image.recognition (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. image.recognition (v2). Premier-only."""
         body: dict[str, Any] = {}
         body["image_b64"] = image_b64
         body["eaten_foods.food_id"] = eaten_foods_food_id
@@ -92,7 +92,7 @@ class NativeResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """natural.language.processing (v1). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. natural.language.processing (v1). Premier-only."""
         body: dict[str, Any] = {}
         body["user_input"] = user_input
         body["eaten_foods.food_id"] = eaten_foods_food_id

--- a/src/fatsecret/resources/_generated/profile_foods.py
+++ b/src/fatsecret/resources/_generated/profile_foods.py
@@ -62,7 +62,7 @@ class ProfileFoodsResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> Any:
-        """food.create (v1). DEPRECATED upstream. Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food.create (v1). DEPRECATED upstream. Premier-only."""
         params: dict[str, Any] = {"method": "food.create"}
         params["brand_name"] = brand_name
         params["food_name"] = food_name
@@ -131,7 +131,7 @@ class ProfileFoodsResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> Any:
-        """food.create (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. food.create (v2). Premier-only."""
         params: dict[str, Any] = {"method": "food.create.v2"}
         params["brand_name"] = brand_name
         params["food_name"] = food_name

--- a/src/fatsecret/resources/_generated/recipes.py
+++ b/src/fatsecret/resources/_generated/recipes.py
@@ -212,7 +212,7 @@ class RecipesResource(BaseResource):
     def types_get_v1(
         self,
     ) -> list:
-        """recipe_types.get (v1). DEPRECATED upstream. Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. recipe_types.get (v1). DEPRECATED upstream. Premier-only."""
         params: dict[str, Any] = {"method": "recipe_types.get"}
         payload = self._client._call(params)
         raw = self._client._unwrap(payload, "recipe_types", list_key="recipe_type")
@@ -223,7 +223,7 @@ class RecipesResource(BaseResource):
         region: Optional[str] = None,
         language: Optional[str] = None,
     ) -> list:
-        """recipe_types.get (v2). Premier-only."""
+        """No typed model — returns the raw FatSecret response shape. See ``docs/migration-v3.rst`` for details. recipe_types.get (v2). Premier-only."""
         params: dict[str, Any] = {"method": "recipe_types.get.v2"}
         self._client._set_optional(
             params,


### PR DESCRIPTION
## Summary

Three related changes that surface the typed-vs-dict response split for the 4 resources still on raw \`dict\` after v3.0.0:

- **Machine-readable**: every OAS operation now carries an \`x-fatsecret-typed-response\` boolean (always emitted, never inferred from a missing key) so programmatic consumers can discover coverage.
- **Human policy**: \`scripts/oas-sync/CODEGEN-POLICY.md\` documents the no-hand-edits rule, how to add a new typed model, and the escape hatch in \`src/fatsecret/resources/<name>.py\`.
- **IDE-visible**: generated dict-returning methods get a one-line docstring note pointing at \`docs/migration-v3.rst\`.

Implementation:

- Extracted \`_RESPONSE_MODEL_MAP\` from \`emit_resource.py\` into \`scripts/oas-sync/src/oas_sync/model_coverage.py\` as the single source of truth. Both \`assemble.py\` and \`emit_resource.py\` now import from it.
- \`assemble.py\` runs \`derive_unwrap\` over the response schema it just built and looks the \`(tag, unwrap_path, list_key)\` triple up in the shared map.
- Mutators (already typed as \`bool\`) skip the docstring note.

## Verification

- Ran the full pipeline twice; both runs produced byte-identical output.
- The OAS diff is **purely** the addition of new \`x-fatsecret-typed-response\` keys (verified via \`git diff\` filter).
- 820 unit tests pass, 18 skipped.

Spot checks:

- \`food_get_v1\` -> \`x-fatsecret-typed-response: true\` (\`Food\` model)
- \`food_brands_get_v1\` -> \`x-fatsecret-typed-response: false\` (no XSD coverage)
- \`weight_update_v1\` -> \`x-fatsecret-typed-response: false\` (mutator)
- Sample dict-only docstring (\`foods.autocomplete v1\`):
  \`\`\`
  No typed model -- returns the raw FatSecret response shape.
  See \`\`docs/migration-v3.rst\`\` for details. foods.autocomplete (v1).
  DEPRECATED upstream. Premier-only.
  \`\`\`

## Test plan

- [x] \`oas-sync sync\` + \`emit-resource\` for all 11 tags is deterministic across runs
- [x] OAS diff contains no non-typed-response changes
- [x] 804+ unit tests pass (820/820 + 18 skipped)
- [ ] CI \`oas-regen-check\` gate green