### PR TITLE
docs: regroup api.rst by Python resource (drop FatSecret-category grouping)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,12 +12,89 @@ warnings during development, run Python with::
 
 The endpoint methods below are exposed via resource sub-objects on a
 :class:`fatsecret.Fatsecret` instance -- e.g. ``fs.foods.search_v5(...)`` --
-and are grouped under top-level guide categories matching FatSecret's
-official documentation layout (`platform.fatsecret.com/docs/guides/
-<https://platform.fatsecret.com/docs/guides/>`_). Each guide contains one
-subsection per OpenAPI tag (sourced from
-``docs/api-spec/openapi.generated.yaml``). Client-only helpers (auth
-handshake, session lifecycle, time conversion) are listed at the bottom
-under **Client utilities**.
+with one section per Python resource class (the actual import path you
+use). Client-only helpers (auth handshake, session lifecycle, time
+conversion) are listed at the bottom under **Client utilities**.
 
-.. fatsecret-api-groups::
+FoodsResource
+-------------
+
+.. autoclass:: fatsecret.resources.foods.FoodsResource
+   :members:
+
+ClassificationResource
+----------------------
+
+.. autoclass:: fatsecret.resources.classification.ClassificationResource
+   :members:
+
+RecipesResource
+---------------
+
+.. autoclass:: fatsecret.resources.recipes.RecipesResource
+   :members:
+
+ProfileFoodsResource
+--------------------
+
+.. autoclass:: fatsecret.resources.profile_foods.ProfileFoodsResource
+   :members:
+
+DiaryResource
+-------------
+
+.. autoclass:: fatsecret.resources.diary.DiaryResource
+   :members:
+
+ExercisesResource
+-----------------
+
+.. autoclass:: fatsecret.resources.exercises.ExercisesResource
+   :members:
+
+WeightResource
+--------------
+
+.. autoclass:: fatsecret.resources.weight.WeightResource
+   :members:
+
+ProfileResource
+---------------
+
+.. autoclass:: fatsecret.resources.profile.ProfileResource
+   :members:
+
+MealsResource
+-------------
+
+.. autoclass:: fatsecret.resources.meals.MealsResource
+   :members:
+
+NativeResource
+--------------
+
+.. autoclass:: fatsecret.resources.native.NativeResource
+   :members:
+
+FeedbackResource
+----------------
+
+.. autoclass:: fatsecret.resources.feedback.FeedbackResource
+   :members:
+
+Client utilities
+----------------
+
+.. automethod:: fatsecret.Fatsecret.authenticate
+
+.. automethod:: fatsecret.Fatsecret.close
+
+.. automethod:: fatsecret.Fatsecret.fatsecret_authenticate
+
+.. automethod:: fatsecret.Fatsecret.get_authorize_url
+
+.. automethod:: fatsecret.Fatsecret.unix_time
+
+.. automethod:: fatsecret.Fatsecret.valid_response
+
+.. Models section added by separate PR (docs/autodoc-pydantic-and-hide-generated).


### PR DESCRIPTION
## Summary

Replace the two-level FatSecret-category grouping in `docs/api.rst` with a single level: one section per Python resource class. Mirrors how Python users actually think -- "I want to call something on `fs.foods`, where are its methods?" -- instead of forcing them to scan multiple FatSecret categories that interleave methods from different resources.

## What changed

- Drop the custom `.. fatsecret-api-groups::` directive invocation and the multi-level "Foods / Diary / AI" guide grouping.
- Add 11 top-level sections (one per resource), each emitted by a single `.. autoclass:: ... :members:` block:
  - FoodsResource, ClassificationResource, RecipesResource, ProfileFoodsResource, DiaryResource, ExercisesResource, WeightResource, ProfileResource, MealsResource, NativeResource, FeedbackResource
- Preserve the unchanged intro paragraph (with the `_vN` suffix / DeprecationWarning notes) and the **Client utilities** section at the bottom (the 6 auth/utility methods on `Fatsecret`).
- Combined with the recently landed `autodoc_typehints = "description"` setting, autodoc renders parameter tables under each method automatically.

## Why

Under the old structure, "Foods > Food" showed methods pulled from BOTH `FoodsResource` and `ProfileFoodsResource` interleaved -- confusing because they map to different import paths and different accessors (`fs.foods.*` vs `fs.profile_foods.*`). New structure gives one section per class, matching the Python surface 1:1.

## Notes for reviewers

- A parallel PR (`docs/autodoc-pydantic-and-hide-generated`) is appending a Models section to this same file. A trailing Sphinx comment in `api.rst` flags this so the absence of a Models section here is intentional.
- `docs/conf.py`, model files, and source code are untouched.

## Test plan

- [x] `cd docs && uv run sphinx-build -W -b html . _build/html` -- builds clean (0 warnings).
- [x] `_build/html/api.html` contains exactly 11 resource sections + Client utilities, no Models section.
- [x] All methods render grouped by their Python resource class (no FatSecret-category interleaving).