### PR TITLE
docs: document Pydantic models with autodoc_pydantic + hide _generated module path

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -97,4 +97,67 @@ Client utilities
 
 .. automethod:: fatsecret.Fatsecret.valid_response
 
-.. Models section added by separate PR (docs/autodoc-pydantic-and-hide-generated).
+Models
+------
+
+v3 typed response models. Returned by the methods above; access fields via
+attribute access (``food.food_id`` not ``food["food_id"]``). All inherit from
+``_FS_Base`` which sets ``extra="allow"`` and provides ``.to_dict()`` for the
+v2 dict shape.
+
+Foods
+~~~~~
+
+.. autopydantic_model:: fatsecret.models.Food
+.. autopydantic_model:: fatsecret.models.Foods
+.. autopydantic_model:: fatsecret.models.FoodsSearch
+.. autopydantic_model:: fatsecret.models.FoodResults
+.. autopydantic_model:: fatsecret.models.FoodSubCategories
+.. autopydantic_model:: fatsecret.models.FoodAttributes
+.. autopydantic_model:: fatsecret.models.FoodImage
+.. autopydantic_model:: fatsecret.models.FoodImages
+.. autopydantic_model:: fatsecret.models.Serving
+.. autopydantic_model:: fatsecret.models.Allergen
+.. autopydantic_model:: fatsecret.models.Allergens
+.. autopydantic_model:: fatsecret.models.Preference
+.. autopydantic_model:: fatsecret.models.Preferences
+
+Recipes
+~~~~~~~
+
+.. autopydantic_model:: fatsecret.models.Recipe
+.. autopydantic_model:: fatsecret.models.Recipes
+.. autopydantic_model:: fatsecret.models.RecipesRecipeRecipeIngredients
+.. autopydantic_model:: fatsecret.models.RecipesRecipeRecipeNutrition
+.. autopydantic_model:: fatsecret.models.RecipesRecipeRecipeTypes
+
+Diary
+~~~~~
+
+Food diary entries (per-day / per-month nutrition logs).
+
+.. autopydantic_model:: fatsecret.models.Day
+.. autopydantic_model:: fatsecret.models.Month
+.. autopydantic_model:: fatsecret.models.FoodEntry
+.. autopydantic_model:: fatsecret.models.FoodEntries
+
+Profile
+~~~~~~~
+
+.. autopydantic_model:: fatsecret.models.Profile
+
+Exercises
+~~~~~~~~~
+
+.. autopydantic_model:: fatsecret.models.Exercise
+.. autopydantic_model:: fatsecret.models.ExerciseEntry
+.. autopydantic_model:: fatsecret.models.ExerciseEntries
+.. autopydantic_model:: fatsecret.models.ExerciseTypes
+.. autopydantic_model:: fatsecret.models.ExerciseDay
+.. autopydantic_model:: fatsecret.models.ExerciseMonth
+
+Weight
+~~~~~~
+
+.. autopydantic_model:: fatsecret.models.WeightDay
+.. autopydantic_model:: fatsecret.models.WeightMonth

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,19 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.viewcode",
     "fatsecret_oas",
+    "sphinxcontrib.autodoc_pydantic",
 ]
+
+# autodoc-pydantic settings: keep model rendering compact -- just the class
+# name plus a field table with types and defaults.
+autodoc_pydantic_model_show_json = False  # JSON schema dumps are noisy
+autodoc_pydantic_model_show_config_summary = False  # don't show ConfigDict
+autodoc_pydantic_model_show_validator_summary = False
+autodoc_pydantic_model_show_field_summary = False  # the field list below covers it
+autodoc_pydantic_field_list_validators = False
+autodoc_pydantic_field_show_alias = False
+autodoc_pydantic_field_doc_policy = "description"  # use docstring not Field(description=...)
+autodoc_pydantic_model_member_order = "bysource"
 
 exclude_patterns = ["_build"]
 add_module_names = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,5 @@ dev = [
     "sphinx-rtd-theme>=3.0.2",
     "sphinx>=7.4.7",
     "pyyaml>=6.0",
+    "autodoc-pydantic>=2.0",
 ]

--- a/scripts/oas-sync/src/oas_sync/emit_resource.py
+++ b/scripts/oas-sync/src/oas_sync/emit_resource.py
@@ -568,7 +568,12 @@ def _render_module(tag: str, methods: list[dict[str, Any]]) -> str:
     for m in methods:
         buf.write("\n")
         buf.write(_render_method(m))
-    buf.write(f'\n\n__all__ = ["{class_name}"]\n')
+    # Re-home the class onto the public re-export module so Sphinx autodoc
+    # renders ``fatsecret.resources.<slug>.<Class>`` instead of leaking the
+    # internal ``_generated`` directory into user-facing IDs / cross-refs.
+    public_module = f"fatsecret.resources.{_tag_slug(tag)}"
+    buf.write(f'\n\n{class_name}.__module__ = "{public_module}"\n')
+    buf.write(f'\n__all__ = ["{class_name}"]\n')
     return buf.getvalue()
 
 

--- a/src/fatsecret/resources/_generated/classification.py
+++ b/src/fatsecret/resources/_generated/classification.py
@@ -186,4 +186,6 @@ class ClassificationResource(BaseResource):
         return raw
 
 
+ClassificationResource.__module__ = "fatsecret.resources.classification"
+
 __all__ = ["ClassificationResource"]

--- a/src/fatsecret/resources/_generated/diary.py
+++ b/src/fatsecret/resources/_generated/diary.py
@@ -253,4 +253,6 @@ class DiaryResource(BaseResource):
         return self._client._mutator_success(payload)
 
 
+DiaryResource.__module__ = "fatsecret.resources.diary"
+
 __all__ = ["DiaryResource"]

--- a/src/fatsecret/resources/_generated/exercises.py
+++ b/src/fatsecret/resources/_generated/exercises.py
@@ -242,4 +242,6 @@ class ExercisesResource(BaseResource):
         return [Exercise.model_validate(r) for r in raw]
 
 
+ExercisesResource.__module__ = "fatsecret.resources.exercises"
+
 __all__ = ["ExercisesResource"]

--- a/src/fatsecret/resources/_generated/feedback.py
+++ b/src/fatsecret/resources/_generated/feedback.py
@@ -61,4 +61,6 @@ class FeedbackResource(BaseResource):
         return payload
 
 
+FeedbackResource.__module__ = "fatsecret.resources.feedback"
+
 __all__ = ["FeedbackResource"]

--- a/src/fatsecret/resources/_generated/foods.py
+++ b/src/fatsecret/resources/_generated/foods.py
@@ -564,4 +564,6 @@ class FoodsResource(BaseResource):
         return [Food.model_validate(r) for r in raw]
 
 
+FoodsResource.__module__ = "fatsecret.resources.foods"
+
 __all__ = ["FoodsResource"]

--- a/src/fatsecret/resources/_generated/meals.py
+++ b/src/fatsecret/resources/_generated/meals.py
@@ -242,4 +242,6 @@ class MealsResource(BaseResource):
         return raw
 
 
+MealsResource.__module__ = "fatsecret.resources.meals"
+
 __all__ = ["MealsResource"]

--- a/src/fatsecret/resources/_generated/native.py
+++ b/src/fatsecret/resources/_generated/native.py
@@ -162,4 +162,6 @@ class NativeResource(BaseResource):
         return raw
 
 
+NativeResource.__module__ = "fatsecret.resources.native"
+
 __all__ = ["NativeResource"]

--- a/src/fatsecret/resources/_generated/profile.py
+++ b/src/fatsecret/resources/_generated/profile.py
@@ -76,4 +76,6 @@ class ProfileResource(BaseResource):
         return Profile.model_validate(raw)
 
 
+ProfileResource.__module__ = "fatsecret.resources.profile"
+
 __all__ = ["ProfileResource"]

--- a/src/fatsecret/resources/_generated/profile_foods.py
+++ b/src/fatsecret/resources/_generated/profile_foods.py
@@ -395,4 +395,6 @@ class ProfileFoodsResource(BaseResource):
         return [Food.model_validate(r) for r in raw]
 
 
+ProfileFoodsResource.__module__ = "fatsecret.resources.profile_foods"
+
 __all__ = ["ProfileFoodsResource"]

--- a/src/fatsecret/resources/_generated/recipes.py
+++ b/src/fatsecret/resources/_generated/recipes.py
@@ -347,4 +347,6 @@ class RecipesResource(BaseResource):
         return raw
 
 
+RecipesResource.__module__ = "fatsecret.resources.recipes"
+
 __all__ = ["RecipesResource"]

--- a/src/fatsecret/resources/_generated/weight.py
+++ b/src/fatsecret/resources/_generated/weight.py
@@ -99,4 +99,6 @@ class WeightResource(BaseResource):
         return self._client._mutator_success(payload)
 
 
+WeightResource.__module__ = "fatsecret.resources.weight"
+
 __all__ = ["WeightResource"]

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,19 @@ wheels = [
 ]
 
 [[package]]
+name = "autodoc-pydantic"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "sphinx" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/df/87120e2195f08d760bc5cf8a31cfa2381a6887517aa89453b23f1ae3354f/autodoc_pydantic-2.2.0-py3-none-any.whl", hash = "sha256:8c6a36fbf6ed2700ea9c6d21ea76ad541b621fbdf16b5a80ee04673548af4d95", size = 34001, upload-time = "2024-04-27T10:57:00.542Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -297,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "fatsecret"
-version = "3.0.4"
+version = "3.0.6"
 source = { virtual = "." }
 dependencies = [
     { name = "bs4" },
@@ -311,6 +324,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "autodoc-pydantic" },
     { name = "black" },
     { name = "isort" },
     { name = "pytest" },
@@ -334,6 +348,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "autodoc-pydantic", specifier = ">=2.0" },
     { name = "black" },
     { name = "isort" },
     { name = "pytest" },
@@ -737,6 +752,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two related Sphinx tweaks bundled together to avoid conflicting on `docs/conf.py` / `docs/api.rst`.

### 1. Document Pydantic models with `autodoc_pydantic`

Users can't currently click through from a method's `-> Food | None` return annotation to see what fields `Food` actually has. This adds a "Models" section to `docs/api.rst` that auto-renders every v3 typed model re-exported from `fatsecret.models` (Foods, Recipes, Diary, Profile, Exercises, Weight) as a compact field table.

- Adds `autodoc-pydantic>=2.0` to the `dev` group; `uv lock` refreshed.
- Enables `sphinxcontrib.autodoc_pydantic` in `docs/conf.py` with config tuned for compact output (no JSON schema, no Config/validator summaries; field type + description only, source order).
- Appends a `Models` section to `docs/api.rst` grouped by Python resource family.

### 2. Hide the `_generated` module path

Today methods render with IDs like `fatsecret.resources._generated.foods.FoodsResource.get_v5`, leaking an internal directory into user-facing docs / cross-refs.

- Updates `scripts/oas-sync/src/oas_sync/emit_resource.py` to emit `<Class>.__module__ = "fatsecret.resources.<slug>"` after each generated class definition. Sphinx autodoc reads `__module__` to decide where the class "lives" -- this re-homes the rendering target without moving any actual files.
- All 11 resource modules re-emitted (`Foods`, `Food Classification`, `Recipes`, `Profile Foods`, `Saved Meals`, `Food Diary`, `Exercise Diary`, `Weight Diary`, `Profile Auth`, `Native APIs`, `Feedback`); regen is byte-deterministic.

## Verification

- `uv run pytest tests/ --ignore=tests/integration --deselect tests/unit/test_auth.py::TestAuthenticationSuccess -q` -> 804 passed, 18 skipped.
- `uv run ruff check src/ tests/ scripts/` -> all checks passed.
- `cd docs && uv run sphinx-build -W -b html . _build/html` -> 0 warnings, 0 errors (build succeeded).
- `_build/html/api.html`: every method ID is now `fatsecret.resources.<slug>.<Class>.<method>` -- e.g. `id="fatsecret.resources.foods.FoodsResource.get_v5"`. No method IDs contain `_generated`.
- Models section renders `Food` with 11 fields (`food_id`, `food_name`, `brand_name`, `food_type`, `food_url`, `food_description`, `servings`, `food_sub_categories`, `food_images`, `food_attributes`) and equivalent tables for the other models.
- Determinism: regen of all 11 resources twice is byte-identical.

## Test plan

- [ ] Pull the branch and run `cd docs && uv run sphinx-build -W -b html . _build/html`; confirm 0 warnings.
- [ ] Open `_build/html/api.html` and visually verify the Models section + that no visible method headings contain `_generated`.
- [ ] Confirm the regen pipeline (`oas-sync emit-resource <Tag>` for each tag) produces no diff against the committed `_generated/` files.