### PR TITLE
docs(index): group toctree under Guides/Migration/Reference captions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,42 +50,28 @@ Once you have created a session then you can start reading from Fatsecret's publ
 
     foods = fs.foods_search_v5("Tacos")        # latest upstream version
 
-Migrating to v3
----------------
+Documentation
+-------------
 
 v3.0 returns typed Pydantic models from the namespaced API surface
-instead of plain dicts. See the migration guide for side-by-side
-v2-vs-v3 examples and the ``.to_dict()`` escape hatch.
+instead of plain dicts. The guides below cover migration, task-oriented
+usage recipes, OAuth authentication, and the full API reference.
 
 .. toctree::
     :maxdepth: 2
+    :caption: Guides
 
     migration-v3
-
-Usage Examples
---------------
-
-Task-oriented recipes for common workflows on the v3 namespaced surface.
-
-.. toctree::
-    :maxdepth: 2
-
     examples
 
-OAuth Examples
---------------
-
-You will need to authenticate to a Fatsecret user profile via OAuth 1.0 in order to access profile specific
-data such as the meal diary, favorite meals, etc.
-
 .. toctree::
     :maxdepth: 2
+    :caption: Migration
 
     usage
 
-API Reference
--------------
 .. toctree::
     :maxdepth: 2
+    :caption: Reference
 
     api


### PR DESCRIPTION
## Summary

Replace the flat per-section toctrees in ``docs/index.rst`` with three captioned toctree groups so the left sidebar conveys hierarchy instead of listing every page as a peer.

## New sidebar layout

```
Guides
  - Migrating to v3
  - Usage Examples
Migration
  - OAuth Examples (usage)
Reference
  - API Documentation
```

## Changes

- ``docs/index.rst``: collapsed four standalone section headings + toctrees into three ``:caption:``-bearing toctrees. No new pages, no removed pages, no changes to ``conf.py``, ``api.rst``, or any other doc.
- Line count: 92 -> 78 (7 insertions, 21 deletions).

## Test plan

- [x] ``cd docs && uv run sphinx-build -W -b html . _build/html`` -> build succeeded, 0 warnings.
- [ ] Reviewer: open ``_build/html/index.html`` and confirm sidebar shows three captioned groups (Guides / Migration / Reference).