### PR TITLE
docs(api): rename section headings to FatSecret category names

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,72 +12,74 @@ warnings during development, run Python with::
 
 The endpoint methods below are exposed via resource sub-objects on a
 :class:`fatsecret.Fatsecret` instance -- e.g. ``fs.foods.search_v5(...)`` --
-with one section per Python resource class (the actual import path you
-use). Client-only helpers (auth handshake, session lifecycle, time
-conversion) are listed at the bottom under **Client utilities**.
+with one section per FatSecret API category. Each section's class
+signature shows the Python class you use (e.g. ``FoodsResource`` for the
+``Foods`` category). Client-only helpers (auth handshake, session
+lifecycle, time conversion) are listed at the bottom under **Client
+utilities**.
 
-FoodsResource
--------------
+Foods
+-----
 
 .. autoclass:: fatsecret.resources.foods.FoodsResource
    :members:
 
-ClassificationResource
-----------------------
+Food Classification
+-------------------
 
 .. autoclass:: fatsecret.resources.classification.ClassificationResource
    :members:
 
-RecipesResource
----------------
+Recipes
+-------
 
 .. autoclass:: fatsecret.resources.recipes.RecipesResource
    :members:
 
-ProfileFoodsResource
---------------------
+Profile Foods
+-------------
 
 .. autoclass:: fatsecret.resources.profile_foods.ProfileFoodsResource
    :members:
 
-DiaryResource
--------------
+Food Diary
+----------
 
 .. autoclass:: fatsecret.resources.diary.DiaryResource
    :members:
 
-ExercisesResource
------------------
+Exercise Diary
+--------------
 
 .. autoclass:: fatsecret.resources.exercises.ExercisesResource
    :members:
 
-WeightResource
---------------
+Weight
+------
 
 .. autoclass:: fatsecret.resources.weight.WeightResource
    :members:
 
-ProfileResource
----------------
+Profile
+-------
 
 .. autoclass:: fatsecret.resources.profile.ProfileResource
    :members:
 
-MealsResource
--------------
+Saved Meals
+-----------
 
 .. autoclass:: fatsecret.resources.meals.MealsResource
    :members:
 
-NativeResource
---------------
+AI
+--
 
 .. autoclass:: fatsecret.resources.native.NativeResource
    :members:
 
-FeedbackResource
-----------------
+Feedback
+--------
 
 .. autoclass:: fatsecret.resources.feedback.FeedbackResource
    :members:


### PR DESCRIPTION
## Summary

Replace Python class names (`FoodsResource`, `ClassificationResource`, ...) in `docs/api.rst` section headings with FatSecret's own platform-docs category names. The `.. autoclass::` directives stay unchanged, so each section still renders its actual class signature (e.g. `class FoodsResource(client)`) under the new heading.

The intro paragraph is reworded to describe sections as FatSecret API categories with the Python class shown via the autoclass signature.

## Renamed headings

| Before | After |
|---|---|
| `FoodsResource` | `Foods` |
| `ClassificationResource` | `Food Classification` |
| `RecipesResource` | `Recipes` |
| `ProfileFoodsResource` | `Profile Foods` |
| `DiaryResource` | `Food Diary` |
| `ExercisesResource` | `Exercise Diary` |
| `WeightResource` | `Weight` |
| `ProfileResource` | `Profile` |
| `MealsResource` | `Saved Meals` |
| `NativeResource` | `AI` |
| `FeedbackResource` | `Feedback` |

`Client utilities`, `Models`, and the Models subsections are unchanged.

## Test plan

- [x] `cd docs && uv run sphinx-build -W -b html . _build/html` -> 0 warnings, build succeeded
- [x] Verified rendered TOC in `_build/html/api.html` shows the new section names
- [x] Verified the `class FoodsResource(client)` signature still renders under the `Foods` heading