### PR TITLE
docs(theme): switch from sphinx_rtd_theme to furo

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,5 +1,5 @@
-{% extends "!layout.html" %}
-{% block document %}
+{% extends "!page.html" %}
+{% block content %}
 {% if is_dev_build %}
 <div class="admonition warning" style="margin-bottom: 1em;">
   <p class="admonition-title">v3 in development</p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ exclude_patterns = ["_build"]
 add_module_names = False
 templates_path = ["_templates"]
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Wrap signatures longer than 80 chars onto multiple lines (Sphinx 7.1+).
 # Generated mutator/create methods can take 20+ optional args; rendering them

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
     "pytest-cov",
     "pytest",
     "ruff",
-    "sphinx-rtd-theme>=3.0.2",
+    "furo>=2024.8.6",
     "sphinx>=7.4.7",
     "pyyaml>=6.0",
     "autodoc-pydantic>=2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
 name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -310,7 +322,7 @@ wheels = [
 
 [[package]]
 name = "fatsecret"
-version = "3.0.6"
+version = "3.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "bs4" },
@@ -326,13 +338,13 @@ dependencies = [
 dev = [
     { name = "autodoc-pydantic" },
     { name = "black" },
+    { name = "furo" },
     { name = "isort" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pyyaml" },
     { name = "ruff" },
     { name = "sphinx" },
-    { name = "sphinx-rtd-theme" },
 ]
 
 [package.metadata]
@@ -350,13 +362,29 @@ requires-dist = [
 dev = [
     { name = "autodoc-pydantic", specifier = ">=2.0" },
     { name = "black" },
+    { name = "furo", specifier = ">=2024.8.6" },
     { name = "isort" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff" },
     { name = "sphinx", specifier = ">=7.4.7" },
-    { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
+]
+
+[[package]]
+name = "furo"
+version = "2025.12.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx" },
+    { name = "sphinx-basic-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
 ]
 
 [[package]]
@@ -1014,17 +1042,15 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-rtd-theme"
-version = "3.1.0"
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils" },
     { name = "sphinx" },
-    { name = "sphinxcontrib-jquery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/68/a1bfbf38c0f7bccc9b10bbf76b94606f64acb1552ae394f0b8285bfaea25/sphinx_rtd_theme-3.1.0.tar.gz", hash = "sha256:b44276f2c276e909239a4f6c955aa667aaafeb78597923b1c60babc76db78e4c", size = 7620915, upload-time = "2026-01-12T16:03:31.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/c7/b5c8015d823bfda1a346adb2c634a2101d50bb75d421eb6dcb31acd25ebc/sphinx_rtd_theme-3.1.0-py2.py3-none-any.whl", hash = "sha256:1785824ae8e6632060490f67cf3a72d404a85d2d9fc26bce3619944de5682b89", size = 7655617, upload-time = "2026-01-12T16:03:28.101Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
 ]
 
 [[package]]
@@ -1052,18 +1078,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-jquery"
-version = "4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/f3/aa67467e051df70a6330fe7770894b3e4f09436dea6881ae0b4f3d87cad8/sphinxcontrib-jquery-4.1.tar.gz", hash = "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a", size = 122331, upload-time = "2023-03-14T15:01:01.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl", hash = "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae", size = 121104, upload-time = "2023-03-14T15:01:00.356Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Switch the Sphinx HTML theme from `sphinx_rtd_theme` to [`furo`](https://github.com/pradyunsg/furo), the de facto modern Python library reference theme used by pip, pydantic, attrs, urllib3, twisted, packaging.python.org, and Sphinx itself. Furo gives us a two-pane layout (left TOC, centered content, right page TOC) and native dark mode, replacing the visually dated dashboard-style RTD theme.

## Changes

- `pyproject.toml`: replace `sphinx-rtd-theme>=3.0.2` with `furo>=2024.8.6` in the `dev` dependency group; `uv.lock` regenerated.
- `docs/conf.py`: `html_theme = "furo"`.
- `docs/_templates/layout.html` -> `docs/_templates/page.html`: furo does not support extending `!layout.html` (its `layout.html` is an explicit error page). Renamed the override to `page.html` and switched the v3-in-dev banner from `{% block document %}` to furo's `{% block content %}`.

## Verification

- `uv run sphinx-build -W -b html docs docs/_build/html` builds clean (no warnings).
- Rendered HTML uses furo's CSS classes (`sidebar-drawer`, `class="content"`) and loads `furo.css` / `furo-extensions.css`.
- `READTHEDOCS_VERSION_TYPE=branch` build renders the v3-in-dev banner on `index.html` and `api.html`.

## Test plan

- [ ] CI build succeeds on this branch.
- [ ] Read the Docs branch build of this PR renders the v3-in-dev banner above the page content.
- [ ] Visual review of `index.html`, `api.html`, and a model/resource page in the rendered output.