### PR TITLE
docs(search): enable readthedocs-sphinx-search for full-text RTD search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "fatsecret_oas",
     "sphinxcontrib.autodoc_pydantic",
+    "sphinx_search.extension",
 ]
 
 # autodoc-pydantic settings: keep model rendering compact -- just the class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,5 @@ dev = [
     "sphinx>=7.4.7",
     "pyyaml>=6.0",
     "autodoc-pydantic>=2.0",
+    "readthedocs-sphinx-search>=0.3.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -322,7 +322,7 @@ wheels = [
 
 [[package]]
 name = "fatsecret"
-version = "3.1.2"
+version = "3.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "bs4" },
@@ -343,6 +343,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pyyaml" },
+    { name = "readthedocs-sphinx-search" },
     { name = "ruff" },
     { name = "sphinx" },
 ]
@@ -367,6 +368,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "readthedocs-sphinx-search", specifier = ">=0.3.2" },
     { name = "ruff" },
     { name = "sphinx", specifier = ">=7.4.7" },
 ]
@@ -931,6 +933,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "readthedocs-sphinx-search"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/96/0c51439e3dbc634cf5328ffb173ff759b7fc9abf3276e78bf71d9fc0aa51/readthedocs-sphinx-search-0.3.2.tar.gz", hash = "sha256:277773bfa28566a86694c08e568d5a648cd80f22826545555a764d6d20c365fb", size = 21949, upload-time = "2024-01-15T16:46:22.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/3c/41bc9d7d4d936a73e380423f23996bee1691e17598d8a03c062be6aac640/readthedocs_sphinx_search-0.3.2-py3-none-any.whl", hash = "sha256:58716fd21f01581e6e67bf3bc02e79c77e10dc58b5f8e4c7cc1977e013eda173", size = 21379, upload-time = "2024-01-15T16:46:20.552Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

furo's built-in search box uses Sphinx's basic JS search index — word stems only, no fuzzy match, often misses method/symbol names. The [`readthedocs-sphinx-search`](https://github.com/readthedocs/readthedocs-sphinx-search) extension overlays that same search box with RTD's full-text search API: full content + symbol index, fuzzy match, snippet previews. Used by numpy, pandas, pydantic, FastAPI.

The extension hooks the existing theme search box via JS at runtime, so no template changes are needed and it's theme-agnostic (works with the furo theme we just landed).

## Changes

- Add `readthedocs-sphinx-search>=0.3.2` to `[dependency-groups].dev` in ``pyproject.toml`` (+ ``uv lock``).
- Append ``"sphinx_search.extension"`` to ``extensions`` in ``docs/conf.py``.

## Behavior

- **Locally**: no-op. RTD's search API is a remote endpoint; opening the built HTML still uses Sphinx's basic search.
- **On RTD**: the smart full-index search activates automatically once published.

## Test plan

- [x] ``cd docs && uv run sphinx-build -W -b html . _build/html`` builds clean under ``-W``.
- [x] ``grep`` confirms the extension's JS/CSS bundle (``rtd_sphinx_search.min.js`` / ``.css``) is injected into ``_build/html/index.html``.
- [ ] After merge & RTD build, verify the search overlay activates on https://fatsecret.readthedocs.io/.