### PR TITLE
feat: add Fatsecret.from_unix_time as inverse of unix_time

### DIFF
--- a/src/fatsecret/fatsecret.py
+++ b/src/fatsecret/fatsecret.py
@@ -410,6 +410,18 @@ class Fatsecret:
             raise TypeError("dt must be datetime, date, int, or float")
 
     @staticmethod
+    def from_unix_time(days: int) -> datetime.datetime:
+        """Convert FatSecret-style days-since-epoch back to a naive ``datetime``.
+
+        Inverse of :meth:`unix_time` / :meth:`unix_time_v2`. Returns midnight
+        UTC of the day corresponding to ``days`` (1970-01-01 + ``days``).
+
+        :param days: Number of days since 1970-01-01 (as returned by ``unix_time``).
+        :return: Naive ``datetime.datetime`` at midnight of that day.
+        """
+        return datetime.datetime(1970, 1, 1) + datetime.timedelta(days=days)
+
+    @staticmethod
     def valid_response(response: requests.Response):
         """Validate a JSON API response and extract its data or raise an error."""
         if response.json():

--- a/tests/unit/test_core_utils.py
+++ b/tests/unit/test_core_utils.py
@@ -64,6 +64,24 @@ def test_unix_time_v2_invalid_type():
         assert False, "TypeError not raised for invalid input type"
 
 
+def test_from_unix_time_epoch():
+    assert Fatsecret.from_unix_time(0) == datetime.datetime(1970, 1, 1)
+
+
+def test_from_unix_time_one_day():
+    assert Fatsecret.from_unix_time(1) == datetime.datetime(1970, 1, 2)
+
+
+def test_from_unix_time_roundtrip():
+    dt = datetime.datetime(2025, 6, 15)
+    assert Fatsecret.from_unix_time(Fatsecret.unix_time(dt)) == dt
+
+
+def test_from_unix_time_roundtrip_v2():
+    dt = datetime.datetime(2025, 6, 15)
+    assert Fatsecret.from_unix_time(Fatsecret.unix_time_v2(dt)) == dt
+
+
 def test_unix_time_v2_leap_year():
     dt = datetime.datetime(1972, 1, 1)
     epoch = datetime.datetime(1970, 1, 1)


### PR DESCRIPTION
## Summary

Adds `Fatsecret.from_unix_time(days: int) -> datetime` as a staticmethod on the `Fatsecret` class. It's the inverse of the existing `unix_time` / `unix_time_v2` converters — given an integer N (FatSecret-style days-since-epoch), returns a naive `datetime` at midnight UTC of that day:

```python
return datetime.datetime(1970, 1, 1) + datetime.timedelta(days=days)
```

## Why

`unix_time` / `unix_time_v2` cover the forward direction (datetime → int). The library returns FatSecret's `date_int` field as an integer in several places, and downstream callers consistently re-implement the same two-line `datetime(1970,1,1) + timedelta(days=n)` to convert back. Closing the round-trip lets callers drop that boilerplate.

Discovered while migrating a downstream project off a local wrapper class — the wrapper had its own `convert_unix_to_datetime` doing exactly this, and it was the one piece without a clean upstream replacement.

## Test plan

- [x] Added 4 unit tests in `tests/unit/test_core_utils.py`:
  - epoch (`0 → 1970-01-01`)
  - one-day offset (`1 → 1970-01-02`)
  - round-trip against `unix_time`
  - round-trip against `unix_time_v2`
- [x] `uv run pytest tests/unit/test_core_utils.py` — 16/16 passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)