### PR TITLE
chore: remove orphaned requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-rauth==0.7.3
-requests==2.34.2


### PR DESCRIPTION
## Summary

Deletes top-level `requirements.txt` — a stale single-line file (`requests==2.34.2`, `rauth==0.7.3`) left over from before the uv migration.

## Why

- No workflow, Makefile, or doc references it (verified via `grep -r requirements.txt`).
- `pyproject.toml` + `uv.lock` are the authoritative dependency declaration.
- It contained a hard-pinned `requests==2.34.2` that conflicted with the widened `>=2.32,<3` constraint we just landed.

## Test plan

- [ ] CI passes (no workflow depended on this file)
- [ ] `uv sync` still resolves